### PR TITLE
Corrige texto da caixa amarela que aparece em artigo comentado. O tex…

### DIFF
--- a/opac/webapp/templates/article/includes/related-article.html
+++ b/opac/webapp/templates/article/includes/related-article.html
@@ -8,7 +8,7 @@
                 {% elif related.related_type == "retracted-article" %}
                     {% trans %}Esta retratação retrata o documento{% endtrans %}:
                 {% elif related.related_type == "commentary-article" or related.related_type == "article-commentary" %}
-                    {% trans %}Este adendo adiciona informação ao documento{% endtrans %}:
+                    {% trans %}Este documento possui um comentário{% endtrans %}:
                 {% elif related.related_type == "addendum" %}
                     {% trans %}Este documento possui um adendo{% endtrans %}:
                 {% elif related.related_type == "retraction" %}

--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -2468,6 +2468,9 @@ msgstr "Open"
 #~ msgid "Este documento possui um adendo"
 #~ msgstr "This document has an addendum"
 
+#~ msgid "Este documento possui um comentário"
+#~ msgstr "This document has a comment"
+
 #~ msgid "Este documento possui uma retratação"
 #~ msgstr "This document has a retraction"
 

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -2508,3 +2508,5 @@ msgstr "Ver"
 #~ msgid "Erro referente"
 #~ msgstr "Error de referencia"
 
+#~ msgid "Este documento possui um comentário"
+#~ msgstr "Este documento tiene un comentario"


### PR DESCRIPTION
#### O que esse PR faz?
Corrige texto da caixa amarela que aparece em artigo comentado.
O texto deve indicar que o artigo tem comentário, mas aparece por engano que tem adendo

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Ver https://github.com/scieloorg/opac/issues/2603

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/2603

### Referências
n/a
