### PR TITLE
Ajustes nos cards da Home

### DIFF
--- a/opac/webapp/static/sass/jquery.typeahead.scss
+++ b/opac/webapp/static/sass/jquery.typeahead.scss
@@ -95,8 +95,8 @@
 
 .typeahead__container {
 	position: relative;
-	min-width: 350px;
-	margin: 0 0 0 50px;
+	//min-width: 350px;
+	//margin: 0 0 0 50px;
 }
 
 .typeahead__container * {
@@ -304,7 +304,7 @@
 	left: 0;
 	z-index: 4;
 	width: 100%;
-	min-width: 350px;
+	//min-width: 350px;
 	padding: 5px 0;
 	margin: 2px 0 0;
 	list-style: none;

--- a/opac/webapp/templates/article/includes/recent_articles_row.html
+++ b/opac/webapp/templates/article/includes/recent_articles_row.html
@@ -1,27 +1,17 @@
 
   <div class="card">
     
-    <!--
-    <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="35%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-    -->
-    
     <div class="card-body">
 
         {% if session.lang %}
-          <!--
-          <h5 class="card-title">
-            {{ article.get_title_by_lang(session.lang[:2])|default(_('Documento sem título'), true)|striptags|truncate(50)|capitalize }}
-          </h5>
-          -->
 
           <h5 class="card-title">
             {{ article.get_title_by_lang(session.lang[:2])|default(_('Documento sem título'), true)|striptags|truncate(80)|capitalize }}
           </h5>
+
         {% endif %}
-        
-        <!--
-        <p class="card-text">{{ latest_issue_legend|default('--', True) }}</p>
-        -->
+
         <a href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid) }}" class="btn btn-secondary">{% trans%}Continue lendo{% endtrans %}</a>
     </div>
+    
   </div>

--- a/opac/webapp/templates/collection/index.html
+++ b/opac/webapp/templates/collection/index.html
@@ -62,59 +62,66 @@
             <div class="col-md-6 right">
             </div>
           </div>
-          <div class="levelMenu">
-            <ul>
-              <li>
-                <a href="{{ url_for('.collection_list') }}?status=current">{% trans %}Alfabética{% endtrans %}</a>
-              </li>
-              <li>
-                <a href="{{ url_for('.collection_list_thematic') }}?status=current">{% trans %}Temática{% endtrans %}</a>
-              </li>
-              <li class="periodicals-search">
 
-                <!-- Form search periódicos -->
-                <div class="typeahead__container">
-                  <div class="typeahead__field">
-                    <div class="typeahead__query">
-                      <input placeholder="{% trans %}Busca por periódicos{% endtrans %}" type="search" class="form-control" autocomplete="off" name="tst" id="tst">
+          <div class="scielo__levelMenu mb-4">
+    
+            <div class="container">
+                <div class="row align-items-center">
+                    <div class="col-6 col-sm-3 col-md-2">
+                        <a href="{{ url_for('.collection_list') }}?status=current">{% trans %}Alfabética{% endtrans %}</a>
                     </div>
-                  </div>
-                </div>
+                    <div class="col-6 col-sm-3 col-md-2">
+                        <a href="{{ url_for('.collection_list_thematic') }}?status=current">{% trans %}Temática{% endtrans %}</a>
+                    </div>
+                    <div class="col">
 
-              </li>
-{#               <li>
-                <a href="{{ url_for('.collection_list') }}#publisher">{% trans %}Por instituição{% endtrans %}</a>
-              </li>
-              <li>
-                <a href="{{ url_for('.collection_list') }}#newIssue">{% trans %}Novos números{% endtrans %}</a>
-              </li>
-              <li>
-                <a href="{{ url_for('.collection_list') }}#newJournals">{% trans %}Novos períodicos{% endtrans %}</a>
-              </li>
-              <li>
-                <a href="{{ analytics.urls.other }}">{% trans %}Métricas{% endtrans %}</a>
-              </li> #}
-            </ul>
-            <div class="clearfix"></div>
-          </div>
+                        <!-- Form search periódicos -->
+                        <div class="typeahead__container">
+                            <div class="typeahead__field">
+                                <div class="typeahead__query">
+                                    <span class="typeahead__cancel-button">×</span><input placeholder="Busca por periódicos" type="search" class="form-control" autocomplete="off" name="tst" id="tst">
+                                </div>
+                            </div>
+                        </div>
+                        
+                    </div>
+                    
+                    {#
+                    <!--
+                    <li>
+                      <a href="{{ url_for('.collection_list') }}#publisher">{% trans %}Por instituição{% endtrans %}</a>
+                    </li>
+                    <li>
+                      <a href="{{ url_for('.collection_list') }}#newIssue">{% trans %}Novos números{% endtrans %}</a>
+                    </li>
+                    <li>
+                      <a href="{{ url_for('.collection_list') }}#newJournals">{% trans %}Novos períodicos{% endtrans %}</a>
+                    </li>
+                    <li>
+                      <a href="{{ analytics.urls.other }}">{% trans %}Métricas{% endtrans %}</a>
+                    </li> 
+                    -->
+                    #}
+
+                </div>
+            </div>
+        </div>
+
+
         </div>
       </div>
       {% if press_releases %}
         <div class="row">
           <div class="block releases">
             <div class="col-md-12">
+              
               <h2>SciELO <span>Press Releases</span></h2>
-              <div class="slider" id="pressreleases">
-                <a href="javascript:;" class="slide-back"><span class="glyphBtn arrowLeft"></span></a>
-                <a href="javascript:;" class="slide-next"><span class="glyphBtn arrowRight"></span></a>
-                <div class="slide-container">
-                  <div class="slide-wrapper">
-                    {% for press_release in press_releases %}
-                      {% include "press_release/includes/press_releases_row.html" %}
-                    {% endfor %}
-                  </div>
-                </div>
+              <div class="scielo-slider">
+                {% for press_release in press_releases %}
+                  {% include "press_release/includes/press_releases_row.html" %}
+                {% endfor %}
               </div>
+
             </div>
             
           </div>
@@ -126,17 +133,13 @@
           <div class="block perspective">
             <div class="col-md-12">
               <h2>SciELO <span>{% trans %}em perspectiva{% endtrans %}</span></h2>
-              <div class="slider" id="perspective">
-                <a href="javascript:;" class="slide-back"><span class="glyphBtn arrowLeft"></span></a>
-                <a href="javascript:;" class="slide-next"><span class="glyphBtn arrowRight"></span></a>
-                <div class="slide-container">
-                  <div class="slide-wrapper">
-                    {% for item in news %}
-                      {% include "news/includes/collection_news_row.html" %}
-                    {% endfor %}
-                  </div>
-                </div>
+              <div class="scielo-slider">
+                {% for item in news %}
+                  {% include "news/includes/collection_news_row.html" %}
+                {% endfor %} 
               </div>
+              
+            
             </div>
             
           </div>

--- a/opac/webapp/templates/news/includes/collection_news_row.html
+++ b/opac/webapp/templates/news/includes/collection_news_row.html
@@ -1,41 +1,24 @@
-<!--
-<div class="slide-item release">
-  <div class="col-md-12">
-    <a href="{{ item.url }}" target="_blank">
-      <span>{{ item.publication_date|datetimefilter }}</span>
-      {% if item.image_url %}
-          <img src="{{ item.image_url }}">
-      {% else %}
-          <img src="../../static/img/img-post-blog-scielo-exemplo.jpg">
-      {% endif %}
-      <h3 class="ellipsis">{{ item.title }}</h3>
-      <div class="info">
-        <div class="ellipsis">
-          {{ item.description|striptags|replace('Read More →', '') }}
-          <br>
-        </div>
-        <strong>{% trans%}continue lendo{% endtrans %} &raquo;</strong>
-      </div>
-    </a>
-  </div>
-</div>
--->
 
 
-<div class="slide-item release">
-  <div class="card">
-    {% if item.image_url %}
-      <img src="{{ item.image_url }}">
-    {% else %}
-      <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="35%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-    {% endif %}
-    <div class="card-body">
+<div class="card">
+  
+  {% if item.image_url %}
+      <img src="{{ item.image_url }}" class="card-img-top">
+  {% else %}
+      <img src="../../static/img/img-post-blog-scielo-exemplo.jpg" class="card-img-top">
+  {% endif %}
+  
+  <div class="card-body">
+
       <h6 class="card-subtitle">{{ item.publication_date|datetimefilter }}</h6>
-      <h5 class="card-title">{{ item.title }}</h5>
+      <h5 class="card-title">
+        {{ item.title }}
+      </h5>
       <p class="card-text">
         {{ item.description|striptags|replace('Read More →', '') }}
       </p>
-      <a href="{{ item.url }}" target="_blank" class="btn btn-secondary">{% trans%}Continue lendo{% endtrans %}</a>
-    </div>
+
+      <a href="{{ item.url }}" class="btn btn-secondary">{% trans%}Continue lendo{% endtrans %}</a>
   </div>
+  
 </div>

--- a/opac/webapp/templates/press_release/includes/press_releases_row.html
+++ b/opac/webapp/templates/press_release/includes/press_releases_row.html
@@ -1,25 +1,17 @@
-<!--
-<div class="slide-item release">
-  <div class="col-md-12">
-    <a href="{{ press_release.url }}" target="_blank">
-      <span>{{ press_release.publication_date|datetimefilter }}</span>
-      <h3 class="ellipsis">{{ press_release.title|striptags}}</h3>
-    </a>
-  </div>
-</div>
-<div class="slide-item release">
--->
 
 
+<div class="card">
 
-  <div class="card">
-    <div class="card-body"> 
-      <h6 class="card-subtitle">{{ press_release.publication_date|datetimefilter }}</h6>
-      <h5 class="card-title">{{ press_release.title|striptags}}</h5>
-      <a href="{{ press_release.url }}" target="_blank" class="btn btn-secondary">{% trans%}Continue lendo{% endtrans %}</a>
-    </div>
+  <div class="card-body">
+
+    <h6 class="card-subtitle">{{ press_release.publication_date|datetimefilter }}</h6>
+    
+    <h5 class="card-title">
+      {{ press_release.title|striptags}}
+    </h5>
+    
+    <a href="{{ press_release.url }}" class="btn btn-secondary">{% trans%}Continue lendo{% endtrans %}</a>
+  
   </div>
 
-<!--
 </div>
--->


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona o comportamento de slick slider nos cards da home, padronizando assim com os demais cards.

#### Onde a revisão poderia começar?
Ao receber esse PR, gere os arquivos estáticos css e abra a home do sistema. Os cards devem estar sendo exibidos com o novo formato.

#### Como este poderia ser testado manualmente?
Apenas navegue pela Home.

#### Algum cenário de contexto que queira dar?
É possível que existam muitos cards e por isso apareçam muitos dots para navegação entre eles. Estamos trabalhando para prever uma quantidade maior de cards e solucionar possíveis situações como esta.

### Screenshots
<img width="1175" alt="Screen Shot 2023-05-30 at 08 50 42" src="https://github.com/scieloorg/opac_5/assets/5552212/20d7b3ce-e9a3-4d06-a4e7-dcc58ecf27dc">


#### Quais são tickets relevantes?
Não há tickets para este ajuste.

### Referências


