### PR TITLE
Atualiza alguns itens do OPAC

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1148,7 +1148,7 @@ def render_html_from_xml(article, lang, gs_abstract=False):
     xml = etree.parse(BytesIO(result))
 
     generator = HTMLGenerator.parse(
-        xml, valid_only=False, gs_abstract=gs_abstract, output_style="website"
+        xml, valid_only=False, gs_abstract=gs_abstract, output_style="website", xslt=xslt
     )
 
     return generator.generate(lang), generator.languages

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -34,6 +34,8 @@
 
   {% include "article/includes/modal/translate_version.html" %}
 
+  {% include "article/includes/modal/how_cite.html" %}
+
   {% include "includes/footer.html" %}
 
   {% include "includes/metric_modal.html" %}
@@ -41,31 +43,30 @@
 {% endblock %}
 
 {% block extra_js %}
+<script type="text/javascript" src="{{ url_for('static', filename='js/scielo-article-min.js') }}"></script>
 
-  <!--
-  <script type="text/javascript" src="{{ url_for('static', filename='js/scielo-article-min.js') }}"></script>
-  -->
-  {% if config.USE_PLUMX %}
-    <script type="text/javascript" src="{{ config.PLUMX_METRICS_URL }}"></script>
-  {% endif %}
+{% if config.USE_PLUMX %}
+<script type="text/javascript" src="{{ config.PLUMX_METRICS_JS }}"></script>
+{% endif %}
 
-  {% if config.USE_ALTMETRIC %}
-    <script type="text/javascript" src="https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js"></script>
-  {% endif %}
+{% if config.USE_ALTMETRIC %}
+<script type="text/javascript" src="https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js"></script>
+{% endif %}
 
-  {% if config.USE_SCIENCEOPEN %}
-    <script id="9cf9cf8f-3a99-fe86-4013-f630edbf80ac" src="https://www.scienceopen.com/script/badge2.js" async defer></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='js/scienceopen.js') }}"></script>
-  {% endif %}
+{% if config.USE_SCIENCEOPEN %}
+<script id="9cf9cf8f-3a99-fe86-4013-f630edbf80ac" src="https://www.scienceopen.com/script/badge2.js" async
+  defer></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/scienceopen.js') }}"></script>
+{% endif %}
 
-  {% if config.USE_SCITE %}
-    <script async type="application/javascript" src="{{ config.SCITE_URL}}"></script>
-  {% endif %}
+{% if config.USE_SCITE %}
+<script async type="application/javascript" src="{{ config.SCITE_URL}}"></script>
+{% endif %}
 
-  {% if config.MATHJAX_CDN_URL %}
-    <script sync src="{{ config.MATHJAX_CDN_URL }}" charset="utf-8"></script>
+{% if config.MATHJAX_CDN_URL %}
+<script sync src="{{ config.MATHJAX_CDN_URL }}" charset="utf-8"></script>
 
-    <script>
+<!-- <script>
       var insertScript = function(url, callback, parentNode) {
         var scriptNode = document.createElement("script");
         scriptNode.src = url;
@@ -75,15 +76,177 @@
       var headNode = document.getElementsByTagName("head")[0];
       setTimeout(MathJax.Callback([insertScript, "//badge.dimensions.ai/badge.js", console.log, headNode]), 1500);
     </script>
-  {% else %}
-    <script type="text/javascript" src="//badge.dimensions.ai/badge.js" charset="utf-8" async></script>
-  {% endif %}
+    -->
 
-  <!-- Verifica se o artigo contém artigos relacionados -->
-  {% if article.related_articles %}
-    <script>
-      $('.articleBadge-editionMeta-doi-copyLink').append($('.related-panel').html())
-    </script>
-  {% endif %}
+{% endif %}
+
+<script type="text/javascript" src="//badge.dimensions.ai/badge.js" charset="utf-8" async></script>
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
+
+<!-- xxx Verifica se o artigo contém artigos relacionados -->
+{% if article.related_articles %}
+<script>
+  if (document.querySelectorAll(".article-correction-title").length == 1) {
+    // length == 1: related-panel do site
+    // length == 2: related-panel do site + do packtools
+    $('.articleBadge-editionMeta-doi-copyLink').append($('.related-panel').html())
+  }
+</script>
+{% endif %}
+
+<!-- Verifica se o artigo contém suplemento -->
+{% if article.mat_suppl %}
+<script type="text/javascript">
+  {% for suppl in article.mat_suppl %}
+    elem = document.querySelector("a[href='{{ suppl.url }}']").getElementsByClassName("REPLACE_BY_SUPPLEMENTARY_MATERIAL_TEXT");
+    if (elem) elem[0].parentElement.innerHTML = "{{ suppl.filename }}";
+  {% endfor %}
+</script>
+{% endif %}
+
+<script>
+
+  affiliations = {};
+
+  function add_scimago_image(selector, remove_br=true, add_br_after=true, find_div=false){
+    console.log("here");
+    $(selector).each(
+
+    function () {
+
+      if (remove_br){
+        $(this).find("br").remove()
+      }
+      
+      internal_items = find_div ? $(this).find('div').not(".clearfix") : $(this).not(".clearfix")
+
+      internal_items.each(function () { 
+        self = $(this);
+
+        affiliation_name = $('span:first', self).text();
+        if (affiliation_name){
+            scimago_link = ' <a href="#" target="_blank" class="scimago_link" data-affiliation="' + affiliation_name + '" ><img src="/static/img/scimago.svg" alt="{% trans %} SCImago image{% endtrans %}" height="12" data-toggle="tooltip" data-placement="top" title="{% trans %}Link to SCImago Institutions Rankings{% endtrans %}"></a>';
+            self.append(scimago_link);
+        }
+      });
+
+      if (add_br_after){
+        $(this).after("<br />")
+      }
+
+    });
+
+  }
+
+  add_scimago_image('#ModalScimago .info div')
+  add_scimago_image('.tutors', remove_br=false, add_br_after=false, find_div=true) 
+
+  $(".scimago_link").click(function(e){
+    e.preventDefault();
+
+    affiliation_name = $(this).data("affiliation");
+
+    if (affiliation_name){
+      if (affiliations[affiliation_name]) {
+        window.open(affiliations[affiliation_name], '_blank');
+      } else {
+        $.ajax({
+          type: "GET",
+          async: false,
+          url: "{{ url_for('main.scimago_ir') }}",
+          data: 'q=' + encodeURI(affiliation_name),
+          success: function (data) {
+            if (data) {
+              affiliations[affiliation_name] = '{{ config.SCIMAGO_URL_IR }}' + data
+              window.open(affiliations[affiliation_name], '_blank');
+            }else{
+              toastr.options = {
+                positionClass: 'toast-top-center'
+              };
+              toastr.error('{% trans %}Link temporariamente indisponível{% endtrans%}');
+            }
+          }
+        });
+      }
+    }    
+  });
+
+
+  var howcite_initialized = false;
+
+  $('#ModalHowcite').on('shown.bs.modal', function () {
+
+    if (!howcite_initialized) {
+      initial = {
+        "American Psychological Association": "apa", "Vancouver": "vancouver"
+      }
+
+      $.each(initial, function (key, value) {
+        $.ajax({
+          url: "{{ url_for('main.article_cite_csl', article_id=article.id) }}?style=" + value,
+          dataType: 'html',
+          delay: 250,
+          async: true
+        })
+          .done(function (html) {
+            $("<span><b>" + key + "</b></span>" + "<pre>" + html + "</pre>").insertBefore($("#select_label"));
+          })
+      });
+      howcite_initialized = true;
+    }
+
+    $(".js-data-example-ajax").select2({
+      ajax: {
+        url: "{{ url_for('main.article_cite_csl_list') }}",
+        dataType: 'json',
+        delay: 250,
+        data: function (params) {
+          return {
+            q: params.term, // search term
+          };
+        },
+        processResults: function (data, params) {
+          return {
+            results: data.results
+          };
+        },
+        cache: true
+      },
+      escapeMarkup: function (markup) { return markup; },
+      minimumInputLength: 1,
+      dropdownParent: $('#ModalHowcite')
+    });
+
+    $(document).on('select2:open', () => {
+      document.querySelector('.select2-search__field').focus();
+    });
+
+    $(".js-data-example-ajax").on('select2:select', function (e) {
+      var data = e.params.data;
+
+      $.ajax({
+        url: "{{ url_for('main.article_cite_csl', article_id=article.id) }}?style=" + data.id,
+        dataType: 'html',
+        delay: 250
+      })
+        .done(function (html) {
+
+          if ($('#citation_text').css('display') == 'none') {
+            $('#citation_text').show()
+          }
+
+          $("#citation_text").html(html);
+
+        })
+        .fail(function () {
+          alert("Erro ao tentar obter esse estilo de citação");
+        })
+
+    });
+  });
+
+</script>
+
 
 {% endblock %}

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -18,6 +18,8 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/scielo-article.css') }}" type="text/css" async/>
 -->  
   <link rel="stylesheet" href="{{ url_for('static', filename='css/article.css') }}?v={{ config.VCS_REF }}" type="text/css" async/>
+  <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" async />
+  <link href="//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" rel="stylesheet" async />
 {% endblock %}
 
 {% block content %}
@@ -110,7 +112,6 @@
   affiliations = {};
 
   function add_scimago_image(selector, remove_br=true, add_br_after=true, find_div=false){
-    console.log("here");
     $(selector).each(
 
     function () {

--- a/opac/webapp/templates/article/includes/floating_menu.html
+++ b/opac/webapp/templates/article/includes/floating_menu.html
@@ -147,7 +147,7 @@
                 </a>
               </li>
               <li>
-                <a class="fm-button-child" --data-bs-toggle="tooltip" title="Como citar este artigo" data-mobile-tooltip="Como citar este artigo" data-bs-toggle="modal" data-bs-target="#ModalArticles">
+                <a class="fm-button-child" --data-bs-toggle="tooltip" title="Como citar este artigo" data-mobile-tooltip="Como citar este artigo" data-bs-toggle="modal" data-bs-target="#ModalHowcite">
                   <span class="material-icons-outlined">
                     link
                   </span>

--- a/opac/webapp/templates/base.html
+++ b/opac/webapp/templates/base.html
@@ -275,9 +275,9 @@
       // Garante que o valor do campo share_url é a URL corrente.
       $('#share_url').val(window.location.href);
 
-      moment.locale('{{ session.lang }}');
+      //moment.locale('{{ session.lang }}');
 
-      $("#date").text(moment().format("L HH:mm:ss ZZ"));
+      //$("#date").text(moment().format("L HH:mm:ss ZZ"));
 
     </script>
 

--- a/opac/webapp/templates/issue/includes/alternative_header.html
+++ b/opac/webapp/templates/issue/includes/alternative_header.html
@@ -92,7 +92,7 @@
           </ul>
         </li>
         <li>
-          <a href="{{ config.URL_SEARCH }}?q=*&lang={% if session.lang %}{{ session.lang[:2] }}{% endif %}&filter[ta_cluster][]={% if journal.short_title %}{{ journal.short_title }}{% endif %}" class="showTooltip" data-placement="bottom" title="{% trans %}Buscar{% endtrans %}">
+          <a href="{{ config.URL_SEARCH }}?q=*&lang={% if session.lang %}{{ session.lang[:2] }}{% endif %}&filter[journal_title][]={% if journal.title %}{{ journal.title }}{% endif %}" class="showTooltip" data-placement="bottom" title="{% trans %}Buscar{% endtrans %}">
             <span class="glyphBtn search"></span>
           </a>
         </li>

--- a/opac/webapp/templates/journal/includes/levelMenu.html
+++ b/opac/webapp/templates/journal/includes/levelMenu.html
@@ -72,7 +72,7 @@
       </div>
       <div class="col-md-3 col-sm-3 text-end">
         <div class="btn-group" role="group" aria-label="Basic example">
-          <a href="{{ config.URL_SEARCH }}?q=*&lang={% if session.lang %}{{ session.lang[:2] }}{% endif %}&filter[ta_cluster][]={% if journal.short_title %}{{ journal.short_title }}{% endif %}" class="btn scielo__btn-with-icon--left"><span class="material-icons-outlined">search</span> {% trans %}Buscar{% endtrans %}</a>
+          <a href="{{ config.URL_SEARCH }}?q=*&lang={% if session.lang %}{{ session.lang[:2] }}{% endif %}&filter[journal_title][]={% if journal.title %}{{ journal.title }}{% endif %}" class="btn single"><span class="glyphBtn search"></span> {% trans %}buscar{% endtrans %}</a>
           
           {% if journal.scielo_issn or journal.eletronic_issn or journal.print_issn %}
             <a target="_blank" href="{{ config.METRICS_URL }}/?journal={{ journal.scielo_issn or journal.eletronic_issn or journal.print_issn }}&collection={{ config.OPAC_COLLECTION }}" class="btn scielo__btn-with-icon--left"><span class="material-icons-outlined">show_chart</span> {% trans %}Métricas{% endtrans %}</a>


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR, adiciona na pagina do artigos: 

* O novo formato de como citar o artigo, igual ao do projeto **opac**
* Adiciona o SCIMAGO institution, igual ao do projeto **opac**
* Adiciona o link correto para a busca na **home do periódico**
* Remove javascript que inutilizados que produz erro.

#### Onde a revisão poderia começar?

Por commit.

#### Como este poderia ser testado manualmente?

Rodando a aplicação local e acessando a página do artigo e página do periódico.

#### Algum cenário de contexto que queira dar?

Essas são funcionalidades que existem no projeto opac e deve ser incorporadas no opac_5

### Screenshots

Existe ajuste de interface que precisam ser feitas, veja: 

![Screenshot 2023-08-21 at 05 31 49](https://github.com/scieloorg/opac_5/assets/86991526/8ecd7f5d-e014-4f54-aa4a-4506d745105c)
![Screenshot 2023-08-21 at 05 31 59](https://github.com/scieloorg/opac_5/assets/86991526/c4cd234f-3a2c-427a-946f-def5ee0004b4)

#### Quais são tickets relevantes?
N/A

### Referências
N/A

