### PR TITLE
Atualiza a versão de packtools 3.2.4 (Resolve questões da página do artigo)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -94,5 +94,5 @@ zope.interface==5.5.2
 tox==4.3.5
 PyJWT==2.8.0
 -e git+https://git@github.com/scieloorg/opac_schema@v2.69#egg=Opac_Schema
--e git+https://git@github.com/scieloorg/packtools@3.2.2#egg=packtools
+-e git+https://git@github.com/scieloorg/packtools@3.2.4#egg=packtools
 -e git+https://github.com/scieloorg/scieloh5m5.git@1.9.5#egg=scieloh5m5


### PR DESCRIPTION

#### O que esse PR faz?

Resolve questões da página do artigo

packtools 3.2.4
- Modifica a apresentação de xref[@ref-type="bibr"] (python3) by @robertatakenaka in #520

packtools 3.2.3
- [página do artigo] Corrige apresentação de lista do tipo "simple" by @robertatakenaka in #466
- [opac_5] Resolve apresentação de fn[@fn-type='data-availability'] e da seção que destaca a disponibilidade de dados by @robertatakenaka in #492
- [opac_5] Corrige a ausência do link para o preprint e corrige o rótulo que acompanha o link by @robertatakenaka in #494
- Página do Artigo - Adiciona apresentação de contrib/bio by @robertatakenaka in #507

