### PR TITLE
Alteração para (re)apresentar os artigos filtrados por seções (WIP)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,8 @@ services:
             - OPAC_SSM_SCHEME=http
             - OPAC_SSM_DOMAIN=minio
             - OPAC_SSM_PORT=9000
+            - OPAC_FILTER_SECTION_ENABLE_FOR_MIN_STUDY_AREAS=5
+            - OPAC_FILTER_SECTION_ENABLE=True
 
     nginx:
         image: nginx:latest

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -640,8 +640,10 @@ ALERT_MSG = bool(ALERT_MSG_PT or ALERT_MSG_EN or ALERT_MSG_ES)
 # Google Meta tags
 FORCE_USE_HTTPS_GOOGLE_TAGS = os.environ.get("OPAC_FORCE_USE_HTTPS_GOOGLE_TAGS", True)
 
-# Filtro por seção no TOC
+# Filtros por seção no TOC
 FILTER_SECTION_ENABLE = os.environ.get("OPAC_FILTER_SECTION_ENABLE", False)
+# para uso combinado com FILTER_SECTION_ENABLE
+FILTER_SECTION_ENABLE_FOR_MIN_STUDY_AREAS = int(os.environ.get("OPAC_FILTER_SECTION_ENABLE_FOR_MIN_STUDY_AREAS", 5))
 
 # Linguagens suportados
 ACCESSIBILITY_BY_LANGUAGE = {

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -944,6 +944,11 @@ def issue_toc(url_seg, url_seg_issue):
     if goto_url:
         return redirect(goto_url, code=301)
 
+    if current_app.config["FILTER_SECTION_ENABLE"] and current_app.config["FILTER_SECTION_ENABLE_FOR_MIN_STUDY_AREAS"]:
+        filter_section_enable = (
+            len(journal.study_areas or []) >= current_app.config["FILTER_SECTION_ENABLE_FOR_MIN_STUDY_AREAS"]
+        )
+
     # obtém os documentos
     articles = controllers.get_articles_by_iid(issue.iid, is_public=True)
     if articles:

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -905,6 +905,8 @@ def issue_toc_legacy(url_seg, url_seg_issue):
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def issue_toc(url_seg, url_seg_issue):
     section_filter = None
+    filter_section_enable = bool(current_app.config["FILTER_SECTION_ENABLE"])
+
     goto = request.args.get("goto", None, type=str)
     if goto not in ("previous", "next"):
         goto = None
@@ -991,6 +993,7 @@ def issue_toc(url_seg, url_seg_issue):
             STUDY_AREAS.get(study_area.upper()) for study_area in journal.study_areas
         ],
         "last_issue": journal.last_issue,
+        "filter_section_enable": filter_section_enable,
     }
     return render_template("issue/toc.html", **context)
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -949,18 +949,18 @@ def issue_toc(url_seg, url_seg_issue):
             len(journal.study_areas or []) >= current_app.config["FILTER_SECTION_ENABLE_FOR_MIN_STUDY_AREAS"]
         )
 
-    # obtém os documentos
+    # obtém todos os documentos
     articles = controllers.get_articles_by_iid(issue.iid, is_public=True)
-    if articles:
-        # obtém TODAS as seções dos documentos deste sumário
-        sections = sorted({a.section.upper() for a in articles if a.section})
-    else:
-        # obtém as seções dos documentos deste sumário
-        sections = []
 
-    if current_app.config["FILTER_SECTION_ENABLE"] and section_filter != "":
-        # obtém somente os documentos da seção selecionada
-        articles = [a for a in articles if a.section.upper() == section_filter]
+    # obtém todas as seções
+    sections = sorted({
+        s.upper()
+        for s in articles.item_frequencies("section", normalize=True).keys()
+    })
+
+    # obtém os documentos da seção selecionada
+    if section_filter:
+        articles = articles.filter(section__iexact=section_filter)
 
     # obtém PDF e TEXT de cada documento
     has_math_content = False

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -135,7 +135,7 @@
                     </h2>
                     <!-- Cabeçalho do Issue Toc -->
                     <ul>
-                      {% if config['FILTER_SECTION_ENABLE'] %}
+                      {% if filter_section_enable %}
 
                         {% if sections %}
                           <li>

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -25,7 +25,7 @@
   </div>
 </section>
 
-  <section class="d-none d-md-flex breadcrumb mt-3 mb-5 py-0 py-1">
+  <section class="d-none d-sm-flex breadcrumb mt-3 mb-5 py-0 py-1">
     <div class="container">
       <div class="row">
         <div class="col">
@@ -89,7 +89,7 @@
           <div class="col content issueIndex" id="issueIndex">
 
             <h1 class="h4 pt-1 mb-0">{% trans %}Sumário{% endtrans %}</h1>
-            <strong class="h6 fw-bold">{{ issue_bibliographic_strip|default('--', True) }}</strong>
+            <strong class="h6 fw-bold d-block mb-3">{{ issue_bibliographic_strip|default('--', True) }}</strong>
 
 
               {% if issue.editorial_board %}
@@ -134,33 +134,39 @@
                       {{ issue_bibliographic_strip|default('--', True) }}
                     </h2>
                     <!-- Cabeçalho do Issue Toc -->
-                    <ul>
+                    <ul class="nav nav-pills mb-4">
                       {% if filter_section_enable %}
 
                         {% if sections %}
-                          <li>
-                            <a href="{{this_page_url}}">
+                          <li class="nav-item" role="presentation">
                               {% if section_filter|length == 0 %}
-                                {% trans %}Todas as seções{% endtrans %} <span style="color: #6789d3;">&laquo;</span>
+                                <a href="{{this_page_url}}" class="mb-1 me-1 btn btn-sm btn-secondary active">
+                                  {% trans %}Todas as seções{% endtrans %}
+                                </a>
                               {% else %}
-                                {% trans %}Todas as seções{% endtrans %}
+                                <a href="{{this_page_url}}" class="mb-1 me-1 btn btn-sm btn-secondary">
+                                  {% trans %}Todas as seções{% endtrans %}
+                                </a>
                               {% endif %}
-                            </a>
                           </li>
                         {% endif %}
 
                         {% for section in sections %}
                           {% if section %}
-                            <li>
+                            <li class="nav-item" role="presentation">
                               <form method="post" action="{{this_page_url}}" class="inline">
                                 <input type="hidden" name="section" value="{{ section|upper }}"/>
-                                <button type="submit" name="submit_param" value="submit_value" class="link-button">
+
                                 {% if section_filter|upper == section|upper %}
-                                  {{ section }} <span style="color: #6789d3;">&laquo;</span>
+                                  <button type="submit" name="submit_param" value="submit_value" class="me-1 mb-1 btn btn-sm btn-secondary active">
+                                    {{ section|lower }}
+                                  </button>
                                 {% else %}
-                                  {{ section }}
+                                  <button type="submit" name="submit_param" value="submit_value" class="me-1 mb-1 btn btn-sm btn-secondary">
+                                    {{ section|lower }}
+                                  </button>
                                 {% endif %}
-                                </button>
+
                               </form>
                             </li>
                           {% endif %}

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -152,13 +152,16 @@
                         {% for section in sections %}
                           {% if section %}
                             <li>
-                              <a href="{{this_page_url}}?section={{ section|upper }}">
+                              <form method="post" action="{{this_page_url}}" class="inline">
+                                <input type="hidden" name="section" value="{{ section|upper }}"/>
+                                <button type="submit" name="submit_param" value="submit_value" class="link-button">
                                 {% if section_filter|upper == section|upper %}
                                   {{ section }} <span style="color: #6789d3;">&laquo;</span>
                                 {% else %}
                                   {{ section }}
                                 {% endif %}
-                              </a>
+                                </button>
+                              </form>
                             </li>
                           {% endif %}
                         {% endfor %}


### PR DESCRIPTION
#### O que esse PR faz?
Alteração para (re)apresentar os artigos filtrados por seções.
Em particular, os periódicos multidisciplinares e os de publicação contínua, precisam do filtro de seção para apresentar os artigos. Inicialmente vamos tratar apenas dos periódicos multidisciplinares, devido a questões pendentes sobre correspondências de idiomas das seções.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Altere o valor de `FILTER_SECTION_ENABLE_FOR_MIN_STUDY_AREAS = int(os.environ.get("OPAC_FILTER_SECTION_ENABLE_FOR_MIN_STUDY_AREAS", 5))` para 1 de modo que todas os sumários terão que apresentar as seções.

Acessando os sumários

#### Algum cenário de contexto que queira dar?
Habilitar o sumário depende `OPAC_FILTER_SECTION_ENABLE` estar como `True`.
Para não gerar um link que os usuários possam copiar e para que os buscadores não indexem a página com os artigos filtrados e mostrem menos conteúdo que existem, o link do sumário foi preservado e a seção selecionada é submetida via post e não get.

### Screenshots
<img width="992" alt="Captura de Tela 2024-02-28 às 18 43 41" src="https://github.com/scieloorg/opac_5/assets/505143/ed99c7e9-353c-4c66-99a2-ecd0b4e721c9">

<img width="765" alt="Captura de Tela 2024-02-28 às 18 44 10" src="https://github.com/scieloorg/opac_5/assets/505143/d0d0c047-2439-41af-b5ce-2b4890ccf9f0">

#### Quais são tickets relevantes?
n/a

### Referências
n/a
