### PR TITLE
Corrige a identificação de "último número"

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -773,6 +773,7 @@ def get_issue_nav_bar_data(journal_id=None, issue_id=None):
 
         if not journal.last_issue:
             set_last_issue_and_issue_count(journal.jid)
+            journal = get_journal_by_jid(journal_id)
 
         last_issue = get_issue_by_iid(journal.last_issue.iid)
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -775,19 +775,25 @@ def get_issue_nav_bar_data(journal_id=None, issue_id=None):
         previous = last_issue
         next_ = None
     else:
-        previous = Issue.objects(
-            journal=issue.journal.jid,
-            year__lte=issue.year,
-            order__lte=issue.order,
-            number__ne="ahead",
-        ).order_by("-year", "-volume", "-order").first()
+        try:
+            previous = Issue.objects(
+                journal=issue.journal.jid,
+                year__lte=issue.year,
+                order__lte=issue.order,
+                number__ne="ahead",
+            ).order_by("-year", "-volume", "-order")[1]
+        except IndexError:
+            previous = None
 
-        next_ = Issue.objects(
-            journal=issue.journal.jid,
-            year__gte=issue.year,
-            order__gte=issue.order,
-            number__ne="ahead",
-        ).order_by("year", "volume", "order").first()
+        try:
+            next_ = Issue.objects(
+                journal=issue.journal.jid,
+                year__gte=issue.year,
+                order__gte=issue.order,
+                number__ne="ahead",
+            ).order_by("year", "volume", "order")[1]
+        except IndexError:
+            next_ = None
 
         if not next_:
             next_ = Issue.objects(

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -743,7 +743,7 @@ def get_issues_for_grid_by_jid(jid, **kwargs):
 
     # o primiero item da lista é o último número.
     # condicional para verificar se issues contém itens
-    last_issue = issues[0] if issues else None
+    last_issue = issues[0].journal.last_issue
 
     return {
         "ahead": issue_ahead,  # ahead of print

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -758,15 +758,21 @@ def set_last_issue_and_issue_count(jid):
     """
     O último issue tem que ser um issue regular, não pode ser aop, nem suppl, nem especial
     """
+    j = None
     try:
         order_by = ["-year", "-order"]
-        j = get_journal_by_jid(jid)
         issues = Issue.objects(
             journal=jid,
             type__in=["regular", "volume_issue"],
             is_public=True,
         )
+        j = get_journal_by_jid(jid)
         j.issue_count = issues.count()
+        j.save()
+    except Exception as e:
+        logging.exception(f"Unable to set_last_issue_and_issue_count for {jid}: {e} {type(e)}")
+
+    try:
         last_issue = issues.order_by(*order_by).first()
 
         j.last_issue = LastIssue(
@@ -778,15 +784,26 @@ def set_last_issue_and_issue_count(jid):
             suppl_text=last_issue.suppl_text,
             start_month=last_issue.start_month,
             end_month=last_issue.end_month,
-            # sections=EmbeddedDocumentListField('TranslatedSection'),
-            # cover_url=last_issue.xxxx,
             iid=last_issue.iid,
             url_segment=last_issue.url_segment,
+            sections=last_issue.sections,
         )
-
         j.save()
     except Exception as e:
         logging.exception(f"Unable to set_last_issue_and_issue_count for {jid}: {e} {type(e)}")
+    return j
+
+
+def journal_last_issues():
+    for j in Journal.objects.filter(last_issue=None):
+        j = set_last_issue_and_issue_count(j.jid)
+        if j.last_issue and j.last_issue.url_segment:
+            yield {"journal": j.jid, "last_issue": j.last_issue.url_segment}
+
+    for j in Journal.objects.filter(last_issue__type__nin=["regular", "volume_issue"]):
+        j = set_last_issue_and_issue_count(j.jid)
+        if j.last_issue and j.last_issue.url_segment:
+            yield {"journal": j.jid, "last_issue": j.last_issue.url_segment}
 
 
 def get_issue_by_iid(iid, **kwargs):

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -771,7 +771,7 @@ def get_issue_nav_bar_data(journal_id=None, issue_id=None):
         issue = None
         journal = get_journal_by_jid(journal_id)
 
-        if not journal.last_issue:
+        if not journal.last_issue or journal.last_issue.type not in ("volume_issue", "regular"):
             set_last_issue_and_issue_count(journal)
 
         last_issue = get_issue_by_iid(journal.last_issue.iid)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -593,7 +593,7 @@ def journal_detail(url_seg):
         "news": news,
         "journal_metrics": journal_metrics,
     }
-
+    context.update(controllers.get_issue_nav_bar_data(journal_id=journal.jid))
     return render_template("journal/detail.html", **context)
 
 
@@ -886,7 +886,7 @@ def issue_grid(url_seg):
             STUDY_AREAS.get(study_area.upper()) for study_area in journal.study_areas
         ],
     }
-
+    context.update(controllers.get_issue_nav_bar_data(journal_id=journal.jid))
     return render_template("issue/grid.html", **context)
 
 
@@ -992,6 +992,9 @@ def issue_toc(url_seg, url_seg_issue):
         ],
         "last_issue": journal.last_issue,
     }
+    context.update(
+        controllers.get_issue_nav_bar_data(
+            journal_id=journal.jid, issue_id=issue.iid))
     return render_template("issue/toc.html", **context)
 
 
@@ -1087,6 +1090,9 @@ def aop_toc(url_seg):
         # o primeiro item da lista é o último número.
         "last_issue": journal.last_issue,
     }
+    context.update(
+        controllers.get_issue_nav_bar_data(
+            journal_id=journal.jid, issue_id=aop_issues[0].iid))
 
     return render_template("issue/toc.html", **context)
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -2212,4 +2212,7 @@ def fetch_and_extract_section(collection_acronym, journal_acronym, language):
     return extract_section(content, class_name)
 
 
-
+@restapi.route("/journal_last_issues", methods=["POST", "PUT"])
+@helper.token_required
+def journal_last_issues(*args):
+    return list(controllers.journal_last_issues() or [])

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -344,8 +344,7 @@ def collection_list_feed():
     for journal in journals.items:
 
         if not journal.last_issue:
-            controllers.set_last_issue_and_issue_count(journal.jid)
-            journal = controllers.get_journal_by_url_seg(url_seg)
+            controllers.set_last_issue_and_issue_count(journal)
 
         last_issue = journal.last_issue
 
@@ -614,8 +613,7 @@ def journal_feed(url_seg):
         abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
 
     if not journal.last_issue:
-        controllers.set_last_issue_and_issue_count(journal.jid)
-        journal = controllers.get_journal_by_url_seg(url_seg)
+        controllers.set_last_issue_and_issue_count(journal)
 
     last_issue = journal.last_issue
 
@@ -673,8 +671,7 @@ def about_journal(url_seg):
         abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
 
     if not journal.last_issue:
-        controllers.set_last_issue_and_issue_count(journal.jid)
-        journal = controllers.get_journal_by_url_seg(url_seg)
+        controllers.set_last_issue_and_issue_count(journal)
 
     latest_issue = journal.last_issue
 
@@ -880,8 +877,7 @@ def issue_grid(url_seg):
     issues_data = controllers.get_issues_for_grid_by_jid(journal.id, is_public=True)
 
     if not journal.last_issue:
-        controllers.set_last_issue_and_issue_count(journal.jid)
-        journal = controllers.get_journal_by_url_seg(url_seg)
+        controllers.set_last_issue_and_issue_count(journal)
 
     latest_issue = journal.last_issue
     if latest_issue:

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -705,6 +705,7 @@ def about_journal(url_seg):
     if section_journal_content:
         context["content"] = section_journal_content
 
+    context.update(controllers.get_issue_nav_bar_data(journal.jid))
     return render_template("journal/about.html", **context)
 
 
@@ -882,7 +883,7 @@ def issue_grid(url_seg):
         controllers.set_last_issue_and_issue_count(journal.jid)
         journal = controllers.get_journal_by_url_seg(url_seg)
 
-    last_issue = journal.last_issue
+    latest_issue = journal.last_issue
     if latest_issue:
         latest_issue_legend = descriptive_short_format(
             title=journal.title,
@@ -898,7 +899,7 @@ def issue_grid(url_seg):
 
     context = {
         "journal": journal,
-        "last_issue": last_issue,
+        "last_issue": latest_issue,
         "latest_issue_legend": latest_issue_legend,
         "volume_issue": issues_data["volume_issue"],
         "ahead": issues_data["ahead"],
@@ -1114,7 +1115,6 @@ def aop_toc(url_seg):
     context.update(
         controllers.get_issue_nav_bar_data(
             journal_id=journal.jid, issue_id=aop_issues[0].iid))
-
     return render_template("issue/toc.html", **context)
 
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -676,7 +676,7 @@ def about_journal(url_seg):
         controllers.set_last_issue_and_issue_count(journal.jid)
         journal = controllers.get_journal_by_url_seg(url_seg)
 
-    last_issue = journal.last_issue
+    latest_issue = journal.last_issue
 
     if latest_issue:
         latest_issue_legend = descriptive_short_format(

--- a/opac/webapp/templates/journal/includes/levelMenu.html
+++ b/opac/webapp/templates/journal/includes/levelMenu.html
@@ -18,53 +18,38 @@
           </a>
   
           {# Anterior #}
-          {% if not issue and not last_issue %}
+          {% if previous_item %}
+            {# página do sumário #}
+            <a title="{% trans %}número anterior{% endtrans %}" href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=previous_item.url_segment) }}" class="btn">
+              &laquo; {% trans %}Número anterior{% endtrans %}
+            </a>
+          {% else %}
             <a title="{% trans %}número anterior{% endtrans %}" href="#" class="btn disabled">
               &laquo; {% trans %}Número anterior{% endtrans %}
-            </a>
-          {% elif issue %}
-            {# página do sumário #}
-            <a title="{% trans %}número anterior{% endtrans %}" href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, goto='previous') }}" class="btn">
-              &laquo; {% trans %}Número anterior{% endtrans %}
-            </a>
-          {% elif last_issue %}
-            {# página inicial do periódico ou grid #}
-            <a title="{% trans %}número anterior{% endtrans %}" href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment, goto='previous') }}" class="btn">
-              &laquo; {% trans %}Número anterior{% endtrans %}
-            </a>
+            </a>          
           {% endif %}
   
           {# Atual #}
-          {% if not last_issue %}
+          {% if issue %}
             <a title="{% trans %}número atual{% endtrans %}" href="#" class="btn disabled">
               {% trans %}Número atual{% endtrans %}
             </a>
-          {% elif issue and last_issue.url_segment == issue.url_segment %}
-            {# página do sumário #}
+          {% elif last_issue %}
             <a title="{% trans %}número atual{% endtrans %}" href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}" class="btn active">
-              {% trans %}Número atual{% endtrans %}
-            </a>
-          {% else %}
-            {# página do periódico #}
-            <a title="{% trans %}número atual{% endtrans %}" href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}" class="btn">
               {% trans %}Número atual{% endtrans %}
             </a>
           {% endif %}
   
           {# Próximo #}
-          {% if not issue and not last_issue %}
-            <a title="{% trans %}número seguinte{% endtrans %}" href="#" class="btn disabled">
-              {% trans %}Número seguinte{% endtrans %} &raquo;
-            </a>
-          {% elif issue and last_issue.url_segment != issue.url_segment %}
+          {% if next_item %}
             {# página do sumário #}
-            <a title="{% trans %}número seguinte{% endtrans %}" href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, goto='next') }}" class="btn">
+            <a title="{% trans %}número seguinte{% endtrans %}" href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=next_item.url_segment) }}" class="btn">
               {% trans %}Número seguinte{% endtrans %} &raquo;
             </a>
-          {% elif last_issue %}
+          {% else %}
             {# página do periódico #}
             <a title="{% trans %}número seguinte{% endtrans %}" href="#" class="btn disabled">
-             C {% trans %}Número seguinte{% endtrans %} &raquo;
+               {% trans %}Número seguinte{% endtrans %} &raquo;
             </a>
           {% endif %}
   


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a identificação de "último número".
Um "número" (fascículo) é um fascículo da publicação regular ou contínua, não pode ser considerado nem especial, nem suplemento, nem ahead of print. No entanto, para a navegação entre todos os componentes do periódico (números regulares, contínuos, especiais, suplementos, ahead of print), todos são considerados. 

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Navegando entre as páginas do periódico: home, about, fascículos etc, nas páginas.

Ler #99

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a


#### Quais são tickets relevantes?
#99 

### Referências
n/a
