### PR TITLE
Melhoria em desempenho de "Corrige identificação de último número"

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -754,7 +754,7 @@ def get_issues_for_grid_by_jid(jid, **kwargs):
     }
 
 
-def get_issue_nav_bar_data(journal_id=None, issue_id=None):
+def get_issue_nav_bar_data(journal=None, issue=None):
     """
     Retorna quanto à navegação os itens anterior e posterior,
     a um dado issue, e o último issue regular de um periódico.
@@ -762,15 +762,12 @@ def get_issue_nav_bar_data(journal_id=None, issue_id=None):
     é o último issue regular odendo ter como item posterior
     um suplemento, um número especial, um ahead ou nenhum item
     """
-    if issue_id:
-        issue = get_issue_by_iid(issue_id)
+    if issue:
         journal = issue.journal
         last_issue = None
 
-    elif journal_id:
+    elif journal:
         issue = None
-        journal = get_journal_by_jid(journal_id)
-
         if not journal.last_issue or journal.last_issue.type not in ("volume_issue", "regular"):
             set_last_issue_and_issue_count(journal)
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -581,7 +581,7 @@ def get_journal_by_url_seg(url_seg, **kwargs):
 
     if not url_seg:
         raise ValueError(__("Obrigatório um url_seg."))
-    
+
     return Journal.objects(url_segment=url_seg, **kwargs).first()
 
 
@@ -768,7 +768,10 @@ def get_issue_nav_bar_data(journal=None, issue=None):
 
     elif journal:
         issue = None
-        if not journal.last_issue or journal.last_issue.type not in ("volume_issue", "regular"):
+        if not journal.last_issue or journal.last_issue.type not in (
+            "volume_issue",
+            "regular",
+        ):
             set_last_issue_and_issue_count(journal)
 
         last_issue = get_issue_by_iid(journal.last_issue.iid)
@@ -776,10 +779,14 @@ def get_issue_nav_bar_data(journal=None, issue=None):
     item = issue or last_issue
 
     if item.type == "ahead" or item.number == "ahead":
-        previous = Issue.objects(
-            journal=journal,
-            number__ne="ahead",
-        ).order_by("-year", "-order").first()
+        previous = (
+            Issue.objects(
+                journal=journal,
+                number__ne="ahead",
+            )
+            .order_by("-year", "-order")
+            .first()
+        )
         next_ = None
     else:
         try:
@@ -801,10 +808,14 @@ def get_issue_nav_bar_data(journal=None, issue=None):
             ).order_by("year", "order")[1]
         except IndexError:
             # aop
-            next_ = Issue.objects(
-                journal=journal,
-                number="ahead",
-            ).order_by("-year", "-order").first()
+            next_ = (
+                Issue.objects(
+                    journal=journal,
+                    number="ahead",
+                )
+                .order_by("-year", "-order")
+                .first()
+            )
 
     return {
         "previous_item": previous,
@@ -828,7 +839,9 @@ def set_last_issue_and_issue_count(journal):
         journal.issue_count = issues.count()
         journal.save()
     except Exception as e:
-        logging.exception(f"Unable to set_last_issue_and_issue_count for {journal.id}: {e} {type(e)}")
+        logging.exception(
+            f"Unable to set_last_issue_and_issue_count for {journal.id}: {e} {type(e)}"
+        )
 
     try:
         last_issue = issues.order_by(*order_by).first()
@@ -847,7 +860,9 @@ def set_last_issue_and_issue_count(journal):
         )
         journal.save()
     except Exception as e:
-        logging.exception(f"Unable to set_last_issue_and_issue_count for {journal.id}: {e} {type(e)}")
+        logging.exception(
+            f"Unable to set_last_issue_and_issue_count for {journal.id}: {e} {type(e)}"
+        )
     return journal
 
 
@@ -979,7 +994,7 @@ def get_issue_by_url_seg(url_seg, url_seg_issue):
 
     if not url_seg and url_seg_issue:
         raise ValueError(__("Obrigatório um url_seg e url_seg_issue."))
-    
+
     return Issue.objects.filter(
         journal=journal, url_segment=url_seg_issue, type__ne="pressrelease"
     ).first()
@@ -1960,5 +1975,5 @@ def add_article(
     article = ArticleFactory(
         document_id, data, issue_id, document_order, document_xml_url, repeated_doc_pids
     )
-    
+
     return article.save()

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -768,9 +768,14 @@ def get_issue_nav_bar_data(journal=None, issue=None):
 
     elif journal:
         issue = None
-        if not journal.last_issue or journal.last_issue.type not in (
-            "volume_issue",
-            "regular",
+        if (
+            not journal.last_issue
+            or journal.last_issue.type
+            not in (
+                "volume_issue",
+                "regular",
+            )
+            or not journal.last_issue.url_segment
         ):
             set_last_issue_and_issue_count(journal)
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -598,7 +598,7 @@ def journal_detail(url_seg):
         "news": news,
         "journal_metrics": journal_metrics,
     }
-    context.update(controllers.get_issue_nav_bar_data(journal_id=journal.jid))
+    context.update(controllers.get_issue_nav_bar_data(journal=journal))
     return render_template("journal/detail.html", **context)
 
 
@@ -703,7 +703,7 @@ def about_journal(url_seg):
     if section_journal_content:
         context["content"] = section_journal_content
 
-    context.update(controllers.get_issue_nav_bar_data(journal.jid))
+    context.update(controllers.get_issue_nav_bar_data(journal))
     return render_template("journal/about.html", **context)
 
 
@@ -905,7 +905,7 @@ def issue_grid(url_seg):
             STUDY_AREAS.get(study_area.upper()) for study_area in journal.study_areas
         ],
     }
-    context.update(controllers.get_issue_nav_bar_data(journal_id=journal.jid))
+    context.update(controllers.get_issue_nav_bar_data(journal=journal))
     return render_template("issue/grid.html", **context)
 
 
@@ -1011,9 +1011,7 @@ def issue_toc(url_seg, url_seg_issue):
         ],
         "last_issue": journal.last_issue,
     }
-    context.update(
-        controllers.get_issue_nav_bar_data(
-            journal_id=journal.jid, issue_id=issue.iid))
+    context.update(controllers.get_issue_nav_bar_data(issue=issue))
     return render_template("issue/toc.html", **context)
 
 
@@ -1110,8 +1108,7 @@ def aop_toc(url_seg):
         "last_issue": journal.last_issue,
     }
     context.update(
-        controllers.get_issue_nav_bar_data(
-            journal_id=journal.jid, issue_id=aop_issues[0].iid))
+        controllers.get_issue_nav_bar_data(issue=aop_issues[0]))
     return render_template("issue/toc.html", **context)
 
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -281,7 +281,7 @@ def collection_list():
 
     return render_template(
         "collection/list_journal.html",
-        **{"journals_list": journals_list, "query_filter": query_filter}
+        **{"journals_list": journals_list, "query_filter": query_filter},
     )
 
 
@@ -315,7 +315,7 @@ def collection_list_thematic():
 
     return render_template(
         "collection/list_thematic.html",
-        **{"objects": objects, "query_filter": query_filter, "filter": thematic_filter}
+        **{"objects": objects, "query_filter": query_filter, "filter": thematic_filter},
     )
 
 
@@ -450,7 +450,9 @@ def router_legacy():
                 abort(404, JOURNAL_UNPUBLISH + _(issue.journal.unpublish_reason))
 
             if issue.url_segment and "ahead" in issue.url_segment:
-                return redirect(url_for("main.aop_toc", url_seg=issue.url_segment), code=301)
+                return redirect(
+                    url_for("main.aop_toc", url_seg=issue.url_segment), code=301
+                )
 
             return redirect(
                 url_for(
@@ -689,7 +691,9 @@ def about_journal(url_seg):
     else:
         latest_issue_legend = None
 
-    section_journal_content = fetch_and_extract_section(collection_acronym, journal.acronym, language)
+    section_journal_content = fetch_and_extract_section(
+        collection_acronym, journal.acronym, language
+    )
 
     context = {
         "journal": journal,
@@ -1107,8 +1111,7 @@ def aop_toc(url_seg):
         # o primeiro item da lista é o último número.
         "last_issue": journal.last_issue,
     }
-    context.update(
-        controllers.get_issue_nav_bar_data(issue=aop_issues[0]))
+    context.update(controllers.get_issue_nav_bar_data(issue=aop_issues[0]))
     return render_template("issue/toc.html", **context)
 
 
@@ -2051,6 +2054,7 @@ def scimago_ir():
 def authenticate():
     return helper.auth()
 
+
 @restapi.route("/counter_dict", methods=["GET"])
 def router_counter_dicts():
     """
@@ -2101,16 +2105,16 @@ def router_counter_dicts():
 @helper.token_required
 def journal(*args):
     """
-    This endpoint responds for PUT and POST. 
+    This endpoint responds for PUT and POST.
 
     if in the payload exists the ``id`` field the function ``controllers.add_journal``
-    will update or create. 
+    will update or create.
 
-    A payload example: 
+    A payload example:
 
     { "id": "1678-4464", "logo_url": "http://cadernos.ensp.fiocruz.br/csp/logo.jpeg", "mission": [ { "language": "pt", "value": "Publicar artigos originais que contribuam para o estudo da saúde pública em geral e disciplinas afins, como epidemiologia, nutrição, parasitologia, ecologia e controles de vetores, saúde ambiental, políticas públicas e planejamento em saúde, ciências sociais aplicadas à saúde, dentre outras." }, { "language": "es", "value": "Publicar artículos originales que contribuyan al estudio de la salud pública en general y de disciplinas afines como epidemiología, nutrición, parasitología, ecología y control de vectores, salud ambiental, políticas públicas y planificación en el ámbito de la salud, ciencias sociales aplicadas a la salud, entre otras." }, { "language": "en", "value": "To publish original articles that contribute to the study of public health in general and to related disciplines such as epidemiology, nutrition, parasitology,vector ecology and control, environmental health, public polices and health planning, social sciences applied to health, and others." } ], "title": "Cadernos de Saúde Pública", "title_iso": "Cad. saúde pública", "short_title": "Cad. Saúde Pública", "acronym": "csp", "scielo_issn": "0102-311X", "print_issn": "0102-311X", "electronic_issn": "1678-4464", "status_history": [ { "status": "current", "date": "1999-07-02T00:00:00.000000Z", "reason": "" } ], "subject_areas": [ "HEALTH SCIENCES" ], "sponsors": [ { "name": "CNPq - Conselho Nacional de Desenvolvimento Científico e Tecnológico " } ], "subject_categories": [ "Health Policy & Services" ], "online_submission_url": "http://cadernos.ensp.fiocruz.br/csp/index.php", "contact": { "email": "cadernos@ensp.fiocruz.br", "address": "Rua Leopoldo Bulhões, 1480 , Rio de Janeiro, Rio de Janeiro, BR, 21041-210 , 55 21 2598-2511, 55 21 2598-2508" }, "created": "1999-07-02T00:00:00.000000Z", "updated": "2019-07-19T20:33:17.102106Z"}
     """
-    
+
     payload = request.get_json()
 
     try:
@@ -2125,10 +2129,10 @@ def journal(*args):
 @helper.token_required
 def issue(*args):
     """
-    This endpoint responds for PUT and POST. 
+    This endpoint responds for PUT and POST.
 
     if in the payload exists the ``id`` field the function ``controllers.add_issue``
-    will update or create. 
+    will update or create.
 
     A payload example:
 
@@ -2139,13 +2143,17 @@ def issue(*args):
     params = request.args.to_dict()
 
     if not params.get("journal_id") and not request.json.get("journal_id"):
-        return jsonify({"failed": True, "error": "missing param journal_id"}), 400 
+        return jsonify({"failed": True, "error": "missing param journal_id"}), 400
     else:
         journal_id = params.get("journal_id") or request.json.get("journal_id")
 
     issue_order = params.get("issue_order", None) or request.json.get("issue_order")
 
-    _type = params.get("type") or request.json.get("type") if params.get("type", None) or request.json.get("type") else "regular"
+    _type = (
+        params.get("type") or request.json.get("type")
+        if params.get("type", None) or request.json.get("type")
+        else "regular"
+    )
 
     try:
         issue = controllers.add_issue(payload, journal_id, issue_order, _type)
@@ -2159,10 +2167,10 @@ def issue(*args):
 @helper.token_required
 def article(*args):
     """
-    This endpoint responds for PUT and POST. 
+    This endpoint responds for PUT and POST.
 
     if in the payload exists the ``id`` field the function ``controllers.add_issue``
-    will update or create. 
+    will update or create.
 
     A payload example:
 
@@ -2174,39 +2182,42 @@ def article(*args):
     params = request.args.to_dict()
 
     if not params.get("issue_id") and not request.json.get("issue_id"):
-        return jsonify({"failed": True, "error": "missing param issue_id"}), 400 
+        return jsonify({"failed": True, "error": "missing param issue_id"}), 400
     else:
         issue_id = params.get("issue_id") or request.json.get("issue_id")
 
     if not params.get("article_id") and not request.json.get("article_id"):
-        return jsonify({"failed": True, "error": "missing param article_id"}), 400 
+        return jsonify({"failed": True, "error": "missing param article_id"}), 400
     else:
-        article_id = params.get("article_id")  or request.json.get("article_id")
+        article_id = params.get("article_id") or request.json.get("article_id")
 
     if not params.get("order") and not request.json.get("order"):
-        return jsonify({"failed": True, "error": "missing param order"}), 400 
+        return jsonify({"failed": True, "error": "missing param order"}), 400
     else:
-        order = params.get("order")  or request.json.get("order")
+        order = params.get("order") or request.json.get("order")
 
     if not params.get("article_url") and not request.json.get("article_url"):
-        return jsonify({"failed": True, "error": "missing param article_url"}), 400 
+        return jsonify({"failed": True, "error": "missing param article_url"}), 400
     else:
-        article_url = params.get("article_url")  or request.json.get("article_id")
+        article_url = params.get("article_url") or request.json.get("article_id")
 
     try:
-        article = controllers.add_article(article_id, payload, issue_id, order, article_url)
+        article = controllers.add_article(
+            article_id, payload, issue_id, order, article_url
+        )
     except Exception as ex:
         return jsonify({"failed": True, "error": str(ex)}), 500
     else:
         return jsonify({"failed": False, "id": article.id}), 200
 
+
 def replace_link(section):
     regex = r"^(.*?)(#.*)"
-    links = section.find_all('a', href=True)
+    links = section.find_all("a", href=True)
     for link in links:
-        href = re.match(regex, link['href'])
+        href = re.match(regex, link["href"])
 
-        link['href'] = href.group(2)
+        link["href"] = href.group(2)
     return section
 
 
@@ -2216,23 +2227,27 @@ def normalize_lang_portuguese(language):
     else:
         return language
 
+
 def extract_section(html_content, class_name):
-    soup = BeautifulSoup(html_content, 'html.parser')
-    section = soup.find('section', class_=class_name)
+    soup = BeautifulSoup(html_content, "html.parser")
+    section = soup.find("section", class_=class_name)
     section = replace_link(section=section)
     if section:
-        return str(section) 
+        return str(section)
     else:
         return None
 
+
 def fetch_and_extract_section(collection_acronym, journal_acronym, language):
     """
-     Busca e extrai seção "journalContent" localizada no core.scielo.org
+    Busca e extrai seção "journalContent" localizada no core.scielo.org
     """
     class_name = "journalContent"
     lang = normalize_lang_portuguese(language)
-    url = f"http://core.scielo.org/{lang}/journal/{collection_acronym}/{journal_acronym}/"
-    
+    url = (
+        f"http://core.scielo.org/{lang}/journal/{collection_acronym}/{journal_acronym}/"
+    )
+
     try:
         content = fetch_data(url=url)
     except NonRetryableError as e:

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -344,7 +344,11 @@ def collection_list_feed():
 
     for journal in journals.items:
 
-        if not journal.last_issue:
+        if (
+            not journal.last_issue
+            or journal.last_issue.type not in ("volume_issue", "regular")
+            or not journal.last_issue.url_segment
+        ):
             controllers.set_last_issue_and_issue_count(journal)
 
         last_issue = journal.last_issue
@@ -542,8 +546,6 @@ def journal_detail(url_seg):
     if not journal.is_public:
         abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
 
-    utils.fix_journal_last_issue(journal)
-
     # todo: ajustar para que seja só noticias relacionadas ao periódico
     language = session.get("lang", get_locale())
     news = controllers.get_latest_news_by_lang(language)
@@ -615,7 +617,11 @@ def journal_feed(url_seg):
     if not journal.is_public:
         abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
 
-    if not journal.last_issue:
+    if (
+        not journal.last_issue
+        or journal.last_issue.type not in ("volume_issue", "regular")
+        or not journal.last_issue.url_segment
+    ):
         controllers.set_last_issue_and_issue_count(journal)
 
     last_issue = journal.last_issue
@@ -673,7 +679,11 @@ def about_journal(url_seg):
     if not journal.is_public:
         abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
 
-    if not journal.last_issue:
+    if (
+        not journal.last_issue
+        or journal.last_issue.type not in ("volume_issue", "regular")
+        or not journal.last_issue.url_segment
+    ):
         controllers.set_last_issue_and_issue_count(journal)
 
     latest_issue = journal.last_issue
@@ -881,7 +891,11 @@ def issue_grid(url_seg):
     # A ordenação padrão da função ``get_issues_by_jid``: "-year", "-volume", "-order"
     issues_data = controllers.get_issues_for_grid_by_jid(journal.id, is_public=True)
 
-    if not journal.last_issue:
+    if (
+        not journal.last_issue
+        or journal.last_issue.type not in ("volume_issue", "regular")
+        or not journal.last_issue.url_segment
+    ):
         controllers.set_last_issue_and_issue_count(journal)
 
     latest_issue = journal.last_issue
@@ -954,9 +968,6 @@ def issue_toc(url_seg, url_seg_issue):
     journal = issue.journal
     if not journal.is_public:
         abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
-
-    # completa url_segment do last_issue
-    utils.fix_journal_last_issue(journal)
 
     # goto_next_or_previous_issue (redireciona)
     goto_url = goto_next_or_previous_issue(
@@ -1075,8 +1086,6 @@ def aop_toc(url_seg):
     journal = aop_issues[0].journal
     if not journal.is_public:
         abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
-
-    utils.fix_journal_last_issue(journal)
 
     articles = []
     for aop_issue in aop_issues:


### PR DESCRIPTION
#### O que esse PR faz?
Melhora Corrige identificação de último número". No PR do issue #99, havia uma nova consulta à base de dados que era desnecessária. Também foi eliminada a chamada a `utils.fix_journal_last_issue()`.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Ver #99

#### Algum cenário de contexto que queira dar?
Esta correção foi aplicada no opac https://github.com/scieloorg/opac/pull/2937

### Screenshots
n/a

#### Quais são tickets relevantes?
#99, https://github.com/scieloorg/opac/pull/2937, #108

### Referências
n/a
