### PR TITLE
Correção da chamada do css, Correção do link no título do periódico, remoção do header da tabela do sumário

### DIFF
--- a/opac/webapp/templates/base.html
+++ b/opac/webapp/templates/base.html
@@ -17,11 +17,7 @@
 
     <link rel="icon" href="{{ url_for('static', filename='img/favicon.ico') }}" />
     
-    <link href="https://ds.scielo.org/static/css/bootstrap.css" rel="preload" as="style" onload="this.rel='stylesheet'">
-    <noscript>
-        <link rel="stylesheet" href="https://ds.scielo.org/static/css/bootstrap.css">
-    </noscript>
-    
+    <link href="https://ds.scielo.org/static/css/bootstrap.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>

--- a/opac/webapp/templates/collection/includes/journal_list_row.html
+++ b/opac/webapp/templates/collection/includes/journal_list_row.html
@@ -7,10 +7,7 @@
       {% if not journal.is_active %} 
         <span class="material-icons" style="color: #c63800; vertical-align:sub;font-size:20px;">fiber_manual_record</span>
       {% endif %}
-      <a title="{% trans %}Título do periódico{% endtrans %}"
-         class="collectionLink {% if not journal.is_active %} disabled {% endif %}" href="{{ journal.links.detail }}">
-        <strong class="journalTitle">{{ journal.title }}</strong>,
-      </a>
+      <a title="{% trans %}Título do periódico{% endtrans %}" class="collectionLink {% if not journal.is_active %} disabled {% endif %}" href="{{ journal.links.detail }}"><strong class="journalTitle">{{ journal.title }}</strong></a>,
       <br class="d-block d-lg-none">
       <a title="{% trans %}Grade de número{% endtrans %}"
          href="{{ journal.links.issue_grid }}">

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -91,7 +91,6 @@
             <h1 class="h4 pt-1 mb-0">{% trans %}Sumário{% endtrans %}</h1>
             <strong class="h6 fw-bold">{{ issue_bibliographic_strip|default('--', True) }}</strong>
 
-
               {% if issue.editorial_board %}
                 <a href="" class="expandCollapseContent showTooltip" title="{% trans %}Expandir/recolher conteúdo{% endtrans %}"><span class="glyphBtn opened"></span></a>
               {% endif %}
@@ -176,7 +175,11 @@
                 <table class="table table-hover table-journal-list mb-5">
                   <thead>
                     <tr>
-                      <th>{% trans %}Artigos{% endtrans %}</th>
+                      <th>
+                        <!--
+                        {% trans %}Artigos{% endtrans %}
+                        -->
+                      </th>
                     </tr>
                   </thead>
                 


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a chamada do css do design system para evitar a demora no carregamento.
Corrige o link dos periódicos na listagem de periódicos, removendo a vírgula do link.
Corrige a lista de sumário, removendo o header "Artigos" do topo da lista.

#### Onde a revisão poderia começar?
Carregue os arquivos e de um refresh no sistema. Perceba que o CSS não deve demorar a ser carregado.
Após, navegue até a lista de periódicos e verifique o link de cada um dos periódicos sem a vírgula incluída no link.
Na tela do sumário, perceba que o título "Artigos" foi removido.

#### Como este poderia ser testado manualmente?
Siga os passos descritos anteriormente.

#### Algum cenário de contexto que queira dar?
-

### Screenshots
![Screen Shot 2024-03-27 at 10 11 53](https://github.com/scieloorg/opac_5/assets/5552212/e27fd2c2-da40-4817-8005-6e7e4cffb1c4)
![Screen Shot 2024-03-27 at 10 12 10](https://github.com/scieloorg/opac_5/assets/5552212/467d1c06-b2ce-454b-935e-17c610cecd25)
![Screen Shot 2024-03-27 at 10 12 30](https://github.com/scieloorg/opac_5/assets/5552212/0b3e492e-2a29-48da-a614-eea9220d94d5)


#### Quais são tickets relevantes?
#104 

### Referências
-

