### PR TITLE
Atualiza dependência opac_schema para versão v2.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -94,6 +94,6 @@ zope.interface==5.5.2
 tox==4.3.5
 PyJWT==2.8.0
 tenacity==8.2.3
--e git+https://git@github.com/scieloorg/opac_schema@v2.70#egg=Opac_Schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.8.0#egg=Opac_Schema
 -e git+https://git@github.com/scieloorg/packtools@4.5.0#egg=packtools
 -e git+https://github.com/scieloorg/scieloh5m5.git@1.9.5#egg=scieloh5m5


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza dependência opac_schema para versão v2.8.0

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
1. docker-compose -f docker-compose-dev.yml build --no-cache
2. make up 

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/A

### Referências
n/a

