### PR TITLE
Fix: - cards artigos mais recentes home do periódico - inseridos volu…

### DIFF
--- a/opac/webapp/templates/article/includes/recent_articles_row.html
+++ b/opac/webapp/templates/article/includes/recent_articles_row.html
@@ -2,14 +2,9 @@
   <div class="card">
     
     <div class="card-body">
+        <div class="h6 card-subtitle mb-1">{% trans%}Volume{% endtrans %}: {{ article.issue.volume }} - {% trans%}Publicado em{% endtrans %}: {{ article.publication_date }}</div>
 
         {% if session.lang %}
-
-          <!--
-          <strong class="card-title">
-            {{ article.get_title_by_lang(session.lang[:2])|default(_('Documento sem título'), true)|striptags|truncate(80)|capitalize }}
-          </strong>
-          -->
 
           <strong class="card-title">
             {{ article.get_title_by_lang(session.lang[:2])|default(_('Documento sem título'), true)|striptags|capitalize }}


### PR DESCRIPTION
#### O que esse PR faz?
Insere volume e data de publicação nos cards dos artigos mais recentes na home do periódico

#### Onde a revisão poderia começar?
Carregue os arquivos e navegue até a home do periódico

#### Como este poderia ser testado manualmente?
Apenas siga o passo anterior

#### Algum cenário de contexto que queira dar?
O ajuste de altura dos cards será enviado no design system.

### Screenshots
![Screen Shot 2024-08-22 at 18 28 03](https://github.com/user-attachments/assets/c6864c64-f886-4d86-8d2d-273873ad9756)


#### Quais são tickets relevantes?
-

### Referências
Indique as referências utilizadas para a elaboração do pull request.

