### PR TITLE
Fix: Cards e Share

### DIFF
--- a/opac/webapp/templates/includes/share.html
+++ b/opac/webapp/templates/includes/share.html
@@ -4,15 +4,23 @@
     <span class="material-icons-outlined">share</span>
   </button>
   <ul class="dropdown-menu dropdown-menu-end">
-    <li><a href="javascript:window.print();" class="dropdown-item">{% trans %}Imprimir{% endtrans %}</a></li>
-    <li><a href="{{ url_for('main.collection_list_feed')}}" type="button" class="dropdown-item" target="_blank">RSS</a></li>
-    <li><a href="javascript:;" class="dropdown-item share_modal_id">E-mail</a></li>
-    <li><hr class="dropdown-divider"></li>
-    <li><a class="dropdown-item shareFacebook" href="#">Facebook</a></li>
-    <li><a class="dropdown-item shareTwitter" href="#">X</a></li>
-    <li><a class="dropdown-item shareLinkedIn" href="#">LinkedIn</a></li>
-    <li><a class="dropdown-item shareReddit" href="#">Reddit</a></li>
-    <li><a class="dropdown-item shareCiteULike" href="#">CiteULike</a></li>
-    <li><a class="dropdown-item shareMendeley" href="#">Mendeley</a></li>
+    <li>
+      <div class="a2a_kit a2a_kit_size_24"><a class="d-flex gap-2 dropdown-item a2a_button_whatsapp">Whatsapp</a></div>
+    </li>
+    <li>
+      <div class="a2a_kit a2a_kit_size_24"><a class="d-flex gap-2 dropdown-item a2a_button_bluesky">BlueSky</a></div> 
+    </li>
+    <li>
+      <div class="a2a_kit a2a_kit_size_24"><a class="d-flex gap-2 dropdown-item a2a_button_mastodon">Mastodon</a></div> 
+    </li>
+    <li>
+      <div class="a2a_kit a2a_kit_size_24"><a class="d-flex gap-2 dropdown-item a2a_button_facebook">Facebook</a></div> 
+    </li>
+    <li>
+      <div class="a2a_kit a2a_kit_size_24"><a class="d-flex gap-2 dropdown-item a2a_dd" href="https://www.addtoany.com/share">{% trans %}Mais{% endtrans %}</a></div>
+    </li>
   </ul>
 </div>
+
+<!-- AddToAny -->
+<script async src="https://static.addtoany.com/menu/page.js"></script>

--- a/opac/webapp/templates/journal/detail.html
+++ b/opac/webapp/templates/journal/detail.html
@@ -12,7 +12,7 @@
         </ol>
 
       </div>
-      <div class="col-3 pt-3">
+      <div class="col-6 pt-3">
     
         <!-- share --> 
         {% include "includes/share.html" %}
@@ -116,7 +116,7 @@
           
           {% if press_releases|length > 1 %}
               
-            <div class="scielo-slider" data-autoheight="true">
+            <div class="scielo-slider">
 
               {% for press_release in press_releases  %}
                 {% include "press_release/includes/press_releases_row.html" %}
@@ -150,7 +150,7 @@
            
             <h2 class="scielo__text-title--4">{% trans %}Artigos mais recentes{% endtrans %}</h2>
             
-            <div class="scielo-slider" data-autoheight="true">
+            <div class="scielo-slider">
               {% for article in recent_articles  %}
                 {% include "article/includes/recent_articles_row.html" %}
               {% endfor %}
@@ -174,7 +174,7 @@
               
             <h2 class="scielo__text-title--4">{% trans %}Notícias{% endtrans %}</h2>
 
-            <div class="scielo-slider" data-autoheight="true">
+            <div class="scielo-slider">
               
               {% for item in news  %}
 
@@ -300,7 +300,7 @@
 
               {% if press_releases|length > 1 %}
                   
-                <div class="scielo-slider" data-autoheight="true">
+                <div class="scielo-slider">
 
                   {% for press_release in press_releases  %}
                     {% include "press_release/includes/press_releases_row.html" %}
@@ -330,7 +330,7 @@
            
               <h2 class="scielo__text-title--4">{% trans %}Artigos mais <br class="d-block d-sm-none">recentes{% endtrans %}</h2>
              
-              <div class="scielo-slider" data-autoheight="true">
+              <div class="scielo-slider">
                 {% for article in recent_articles  %}
                   {% include "article/includes/recent_articles_row.html" %}
                 {% endfor %}
@@ -346,7 +346,7 @@
             
               <h2 class="scielo__text-title--4">{% trans %}Notícias{% endtrans %}</h2>
 
-              <div class="scielo-slider" data-autoheight="true">
+              <div class="scielo-slider">
                 
                 {% for item in news  %}
 


### PR DESCRIPTION
Fix: Remoção do atributo autoheight nos slides pois foi feita uma correção no ds que corrige a necessidade deste.
Fix: Inclusão do componente addtoany para elementos share.
Fix: Correção de layout para impedir quebra de layout ao abrir dropdown share na home do periódico no mobile.

#### O que esse PR faz?
Corrige a necessidade da função javascript para redimensionar os cards.
Insere componentes addtoany ao template share, possibilitando uma grande variedade de redes sociais para se compartilhar.

#### Onde a revisão poderia começar?
Carregue os arquivos e navegue no sistema. Todos os dropdowns share devem exibir os novos elementos do addtoany. Ver print.
Os cards serão redimensionados automaticamente após a atualização do design system.

#### Como este poderia ser testado manualmente?
Siga os passos descritos anteriormente.

#### Algum cenário de contexto que queira dar?
O ajuste referente aos cards depende da atualização do design system. Essa atualização remove o atributo height: 100$ do elemento .slick-slide. Com isso, os cards obtém a altura do maior elemento de forma padronizada e global.

### Screenshots
![Screen Shot 2024-10-09 at 12 12 24](https://github.com/user-attachments/assets/56e3f225-d365-45ff-8b50-151edcd8a1d2)
![Screen Shot 2024-10-09 at 12 11 27](https://github.com/user-attachments/assets/e4b6cac5-4650-4c72-879f-670ecc7f43f0)
![Screen Shot 2024-10-09 at 12 11 02](https://github.com/user-attachments/assets/25a9d862-68cd-45d2-b516-d005553e04ab)
![Screen Shot 2024-10-09 at 12 10 46](https://github.com/user-attachments/assets/4e1bba59-4051-456d-a2c9-96c96e8a5a81)


#### Quais são tickets relevantes?
-

### Referências
Indique as referências utilizadas para a elaboração do pull request.

