### PR TITLE
Para a página informativa do journal, cria possibilidade de manter a página do legado, na ausência de conteúdo do Core 

### DIFF
--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -589,6 +589,7 @@ class JournalAdminView(OpacBaseAdminView):
         "eletronic_issn",
         "unpublish_reason",
         "url_segment",
+        "old_information_page",
     ]
 
     column_formatters = dict(
@@ -634,6 +635,7 @@ class JournalAdminView(OpacBaseAdminView):
         is_public=__("Publicado?"),
         unpublish_reason=__("Motivo de despublicação"),
         url_segment=__("Segmento de URL"),
+        old_information_page=__("Manter página informativa legado"),
     )
 
     @action("publish", _("Publicar"), ACTION_PUBLISH_CONFIRMATION_MSG)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -638,11 +638,16 @@ def about_journal(url_seg):
         )
     else:
         latest_issue_legend = None
-
-    section_journal_content = utils.fetch_and_extract_section(
-        collection_acronym, journal.acronym, language
-    )
-
+    
+    if journal.old_information_page:
+        page = controllers.get_page_by_journal_acron_lang(journal.acronym, language)
+        content = page.content
+    else:
+        section_journal_content = utils.fetch_and_extract_section(
+            collection_acronym, journal.acronym, language
+        )
+        content = section_journal_content
+    
     context = {
         "journal": journal,
         "latest_issue_legend": latest_issue_legend,
@@ -652,9 +657,7 @@ def about_journal(url_seg):
         ],
     }
 
-    if section_journal_content:
-        context["content"] = section_journal_content
-
+    context['content'] = content
     context.update(controllers.get_issue_nav_bar_data(journal))
     return render_template("journal/about.html", **context)
 


### PR DESCRIPTION
#### O que esse PR faz?
Para a página informativa do journal, cria possibilidade de manter a página do legado, na ausência de conteúdo do Core 

#### Onde a revisão poderia começar?
Pelos commits

#### Como este poderia ser testado manualmente?
Acessar página informativa de algum periódico

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
![image](https://github.com/user-attachments/assets/865c6ae0-8d71-4e5e-a292-51968b881478)
![image](https://github.com/user-attachments/assets/81b92175-73ee-46c2-bc34-fed7fcf4051b)

#### Quais são tickets relevantes?
#144 
https://github.com/scieloorg/opac_schema/pull/110

### Referências
N/A

