### PR TITLE
Atualiza a versão do opac_schema inclui no rodapé a licença e adiciona a permissão de preservação da clockss

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -191,6 +191,12 @@ import ast
 
       - Interface languages
         - OPAC_LANGUAGES: os idiomas com seus respectivos labels, exemplo: {'pt_BR': 'Português','en': 'English','es': 'Español'}
+
+      - Site License
+        - OPAC_SITE_LICENSE_ENABLE: ativa/desativa a exibição do logo do creative commons no rodapé do site
+        - OPAC_SITE_LICENSE_NAME: Nome da licença (default: "Creative Common - by 4.0")
+        - OPAC_SITE_LICENSE_URL: URL da licença (default: https://creativecommons.org/licenses/by-nc/4.0/)
+        - OPAC_SITE_LICENSE_IMG_URL: Imagem da licença (default: https://licensebuttons.net/l/by/4.0/88x31.png)
 """
 
 PROJECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -671,3 +677,8 @@ COMMON_STYLE_LIST = os.environ.get(
 
 # Citation Export Format
 CITATION_EXPORT_FORMATS = {"bib": "BibTex", "ris": "Reference Manager"}
+
+SITE_LICENSE_ENABLE = os.environ.get("OPAC_SITE_LICENSE_ENABLE", "True") == "True"
+SITE_LICENSE_NAME = os.environ.get("OPAC_SITE_LICENSE_NAME", "Creative Common - by 4.0")
+SITE_LICENSE_URL = os.environ.get("OPAC_SITE_LICENSE_URL", "https://creativecommons.org/licenses/by-nc/4.0/")
+SITE_LICENSE_IMG_URL = os.environ.get("OPAC_SITE_LICENSE_IMG_URL", "https://licensebuttons.net/l/by/4.0/88x31.png")

--- a/opac/webapp/templates/base.html
+++ b/opac/webapp/templates/base.html
@@ -24,6 +24,8 @@
       <script src="{{ url_for('static', filename='js/vendor/html5-3.6-respond-1.1.0.min.js') }}"></script>
     <![endif]-->
 
+    {% include "includes/clockss.html" %}
+
     {% if not config.DEBUG and config.GA_TRACKING_CODE %}
     <!-- Google Analytics -->
       <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.GA_TRACKING_CODE }}"></script>

--- a/opac/webapp/templates/includes/clockss.html
+++ b/opac/webapp/templates/includes/clockss.html
@@ -1,0 +1,10 @@
+<!-- CLOCKSS system has permission to ingest, preserve, and serve this Archival Unit -->
+<div class="widget widget-Lockss widget-instance-IssueBrowseByYear_Lockss">
+
+    <input class="at-locks-messaging" type="hidden"
+        value="LOCKSS system has permission to collect, preserve, and serve this Archival Unit" />
+
+    <input class="at-clockss-messaging" type="hidden"
+        value="CLOCKSS system has permission to ingest, preserve, and serve this Archival Unit" />
+
+</div>

--- a/opac/webapp/templates/includes/footer.html
+++ b/opac/webapp/templates/includes/footer.html
@@ -5,10 +5,23 @@
 				<div class="col col-12 col-sm-2 text-center">
 					<div class="scielo__logo-scielo--small" alt="Logo SciELO"></div>
 				</div>
-				<div class="col col-12 col-sm-10 text-center text-sm-start">
+				<div class="col col-12 col-sm-8 text-center text-sm-start">
 					<p><small><strong> SciELO - Scientific Electronic Library Online</strong></small></p>
 					<p><small>{{ g.collection.address1 or '' }}<br/>
 						{{ g.collection.address2 or '' }}</small></p>
+				</div>
+				<div class="col col-12 col-sm-2 text-center">
+					{% if config.SITE_LICENSE_ENABLE %}
+					<div class="container-license">
+						<div class="row">
+							<div class="col-sm-3 col-md-2">
+								<a href="{{config.SITE_LICENSE_URL}}" target="_blank" title="" rel="license"><img
+										src="{{config.SITE_LICENSE_IMG_URL}}" alt="{{config.SITE_LICENSE_NAME}}">
+								</a>
+							</div>
+						</div>
+					</div>
+					{% endif %}
 				</div>
 			</div>
 		</div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,6 +94,6 @@ zope.interface==5.5.2
 tox==4.3.5
 PyJWT==2.8.0
 tenacity==8.2.3
--e git+https://git@github.com/scieloorg/opac_schema@v2.8.0#egg=Opac_Schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.8.1#egg=Opac_Schema
 -e git+https://git@github.com/scieloorg/packtools@4.5.0#egg=packtools
 -e git+https://github.com/scieloorg/scieloh5m5.git@1.9.5#egg=scieloh5m5


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza a versão do opac_schema inclui no rodapé a licença e adiciona a permissão de preservação da clockss

#### Onde a revisão poderia começar?

Por commit 

#### Como este poderia ser testado manualmente?

Sugiro rodando a aplicação e verificando no HTML as alterações

#### Algum cenário de contexto que queira dar?

Essa atividade é a mesma demanda para o opac, veja: https://github.com/scieloorg/opac/pull/3131

Nesse caso foi necessário que a inclusão da licença fosse responsiva.

### Screenshots

<img width="233" alt="Screenshot 2024-11-05 at 07 42 57" src="https://github.com/user-attachments/assets/d82054cc-9d20-49bc-8351-391158e8bb65">
<img width="1422" alt="Screenshot 2024-11-05 at 07 43 04" src="https://github.com/user-attachments/assets/4024c321-d64f-48d7-a8c1-1105abbcc7ee">
<img width="1399" alt="Screenshot 2024-11-05 at 07 52 26" src="https://github.com/user-attachments/assets/1b86ce25-9a73-4f3a-ae41-51688ab9e316">


#### Quais são tickets relevantes?
[[Indique uma issue ao qual o pull request faz relacionamento.](https://github.com/scieloorg/opac/pull/3131)](https://github.com/scieloorg/opac/issues/3127)
https://github.com/scieloorg/opac/issues/3060

### Referências
N/A

