### PR TITLE
Ajusta os links para as âncoras das páginas informativas dos periódicos

### DIFF
--- a/opac/webapp/templates/journal/includes/journal_info.html
+++ b/opac/webapp/templates/journal/includes/journal_info.html
@@ -87,9 +87,9 @@
           {% if journal.online_submission_url and journal.current_status == 'current' %}
             <a class="list-group-item" href="{{ journal.online_submission_url|default('', true) }}" target="_blank"><span class="material-icons-outlined">launch</span> {% trans %}Submissão de manuscritos{% endtrans %}</a>
           {% endif %}
-            <a class="list-group-item" href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#item-1" class="scroll"><span class="material-icons-outlined">info</span> {% trans %}Sobre o periódico{% endtrans %}</a>
-            <a class="list-group-item" href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#item-3" class="scroll"><span class="material-icons-outlined">people</span> {% trans %}Corpo Editorial{% endtrans %}</a>
-            <a class="list-group-item" href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#item-4" class="scroll"><span class="material-icons-outlined">help_outline</span> {% trans %}Instruções aos autores{% endtrans %}</a>
+            <a class="list-group-item" href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#about" class="scroll"><span class="material-icons-outlined">info</span> {% trans %}Sobre o periódico{% endtrans %}</a>
+            <a class="list-group-item" href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#editors" class="scroll"><span class="material-icons-outlined">people</span> {% trans %}Corpo Editorial{% endtrans %}</a>
+            <a class="list-group-item" href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#instructions" class="scroll"><span class="material-icons-outlined">help_outline</span> {% trans %}Instruções aos autores{% endtrans %}</a>
             <a class="list-group-item" href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#item-2" class="scroll"><span class="material-icons-outlined">article</span> {% trans %}Política editorial{% endtrans %}</a>
           {% if journal.enable_contact %}
               <a class="list-group-item" href="javascript:;" class="contact_modal_id" data-url="{{ url_for('main.form_contact', url_seg=journal.url_segment) }}">


### PR DESCRIPTION
#### O que esse PR faz?
Ajusta os links para as âncoras das páginas informativas dos periódicos

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
1. **Iniciar os Serviços**
     Inicie os serviços dos projetos opac_5 e core.

2. **Selecionar um Periódico**
    Escolha um periódico no OPAC para alterar as páginas informativas.

3. **Configurar a Função fetch_and_extract_section no OPAC**
    No projeto opac, ajuste a função ```opac.webapp.utils.fetch_and_extract_section``` para apontar para o container local 
    do serviço Django do projeto core.
    Observação: Na minha configuração, foi necessário utilizar o gateway da rede Docker para conectar os containers.
Exemplo:
```python
def fetch_and_extract_section(collection_acronym, journal_acronym, language):
    """
    Busca e extrai seção "journalContent" localizada no core.scielo.org
    """
    class_name = "journalContent"
    lang = normalize_lang_portuguese(language)
    url = (
        f"http://172.19.0.1:8009/{lang}/journal/{collection_acronym}/{journal_acronym}/"
    )

    content = fetch_data(url=url)

    return extract_section(content, class_name)
```
4. **Adicionar o Gateway em ALLOWED_HOSTS no Core (Opcional)**
    No projeto core, adicione o IP do gateway da rede Docker em ALLOWED_HOSTS se necessário, conforme definido no 
    passo anterior.

Testar as Páginas Informativas
No opac, acesse a página informativa do periódico escolhido e teste o funcionamento das âncoras.

OBS: Esse teste depende de:  https://github.com/scieloorg/core/pull/895

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#220 
https://github.com/scieloorg/core/pull/895

### Referências
N/A

