### PR TITLE
Adiciona o novo menu flutuante na página do artigo.

### DIFF
--- a/opac/webapp/templates/article/includes/floating_menu.html
+++ b/opac/webapp/templates/article/includes/floating_menu.html
@@ -1,227 +1,119 @@
-<!--
-<div class="floatingMenuCtt">
-  <a class="floatingMenuItem fm-button-child item-goto" data-fm-label="{% trans %}Ir para o topo{% endtrans %}" href="#top">
-    <span class="sci-ico-top glyphFloatMenu"></span>
-  </a>
-
-  <a href="javascript:;" class="floatingMenuItem fm-button-child item-download" data-fm-label="{% trans %}PDFs{% endtrans %}" data-toggle="modal" data-target="#ModalDownloads">
-    <span class="sci-ico-download glyphFloatMenu"></span>
-  </a>
-
-  {% if config.USE_METRICS or config.USE_DIMENSIONS or config.USE_PLUMX %}
-  <a href="javascript:;" data-toggle="modal" data-target="#metric_modal_id" class="floatingMenuItem fm-button-child item-metrics" data-fm-label="{% trans %}Métricas{% endtrans %}" target="_blank">
-    <span class="sci-ico-metrics glyphFloatMenu"></span>
-  </a>
-  {% endif %}
-
-  <ul class="floatingMenu fm-slidein" data-fm-toogle="hover">
-    <li class="fm-wrap">
-      <a href="javascript:;" class="fm-button-main">
-        <span class="sci-ico-floatingMenuDefault glyphFloatMenu"></span>
-        <span class="sci-ico-floatingMenuClose glyphFloatMenu"></span>
-      </a>
-      <ul class="fm-list">
-        {% if not is_pdf_page and article.xml %}
-          {# excluimos este item se é a página do PDF #}
-          <li>
-            <a class="fm-button-child" data-fm-label="{% trans %}Figuras e tabelas{% endtrans %}" data-toggle="modal" data-target="#ModalTablesFigures">
-              <span class="sci-ico-figures glyphFloatMenu"></span>
-            </a>
-          </li>
-        {% endif %}
-        <li>
-          <a class="fm-button-child" data-fm-label="{% trans %}Versões e traduções{% endtrans %}" data-toggle="modal" data-target="#ModalVersionsTranslations">
-            <span class="sci-ico-translation glyphFloatMenu"></span>
-          </a>
-        </li>
-        <li>
-          <a class="fm-button-child" data-fm-label="{% trans %}Como citar este artigo{% endtrans %}" data-toggle="modal" data-target="#ModalArticles">
-            <span class="sci-ico-citation glyphFloatMenu"></span>
-          </a>
-        </li>
-        <li>
-          <a class="fm-button-child" data-fm-label="{% trans %}Artigos relacionados{% endtrans %}" data-toggle="modal" data-target="#ModalRelatedArticles">
-            <span class="sci-ico-similar glyphFloatMenu"></span>
-          </a>
-        </li>
-      </ul>
-    </li>
-  </ul>
-</div>
--->
-
-
-<!-- FLOATING MENU ONLY FOR IPAD-->
-<!--
-<ul class="floatingMenuMobile fm-slidein" data-fm-toogle="hover">
-  <li class="fm-wrap">
-    <a href="javascript:;" class="fm-button-main">
-      <span class="sci-ico-floatingMenuDefault glyphFloatMenu"></span>
-      <span class="sci-ico-floatingMenuClose glyphFloatMenu"></span>
-    </a>
-    <ul class="fm-list">
-      <li>
-        <a class="fm-button-child item-goto" data-fm-label="{% trans %}Ir para o topo{% endtrans %}" href="#top">
-          <span class="sci-ico-top glyphFloatMenu"></span>
-        </a>
-      </li>
-      <li>
-        <a class="fm-button-child item-download" data-fm-label="{% trans %}PDFs{% endtrans %}" data-toggle="modal" data-target="#ModalDownloads" href="#">
-          <span class="sci-ico-download glyphFloatMenu"></span>
-        </a>
-      </li>
-      <li>
-        <a data-toggle="modal" data-target="#metric_modal_id" class="fm-button-child item-metrics" data-fm-label="{% trans %}Métricas{% endtrans %}" href="#" target="_blank">
-          <span class="sci-ico-metrics glyphFloatMenu"></span>
-        </a>
-      </li>
-      {% if not is_pdf_page and article.xml %}
-        {# excluimos este item se é a página do PDF #}
-        <li>
-          <a class="fm-button-child" data-fm-label="{% trans %}Figuras e tabelas{% endtrans %}" data-toggle="modal" data-target="#ModalTablesFigures" href="#">
-            <span class="sci-ico-figures glyphFloatMenu"></span>
-          </a>
-        </li>
-      {% endif %}
-      <li>
-        <a class="fm-button-child" data-fm-label="{% trans %}Versões e traduções{% endtrans %}" data-toggle="modal" data-target="#ModalVersionsTranslations" href="#">
-          <span class="sci-ico-translation glyphFloatMenu"></span>
-        </a>
-      </li>
-      <li>
-        <a class="fm-button-child" data-fm-label="{% trans %}Como citar este artigo{% endtrans %}" data-toggle="modal" data-target="#ModalArticles" href="#">
-          <span class="sci-ico-citation glyphFloatMenu"></span>
-        </a>
-      </li>
-      <li>
-        <a class="fm-button-child" data-fm-label="{% trans %}Artigos e similares{% endtrans %}" data-toggle="modal" data-target="#ModalRelatedArticles" href="#">
-          <span class="sci-ico-similar glyphFloatMenu"></span>
-        </a>
-      </li>
-    </ul>
-  </li>
-</ul>
--->
-<!-- FLOATING MENU ONLY FOR IPAD-->
-
-
-
 
 <div class="container">
-  <div class="row">
-    <div class="col">
-      <div class="scielo__floatingMenuCtt">
-        <a class="scielo__floatingMenuItem fm-button-child item-goto d-none d-sm-inline-block" data-bs-toggle="tooltip" data-bs-original-title="{% trans %}Ir para o topo{% endtrans %}" href="#top">
-          <span class="material-icons-outlined">
-            vertical_align_top
-          </span>
-        </a>
-        <a href="javascript:;" class="scielo__floatingMenuItem fm-button-child item-download d-none d-sm-inline-block" --data-bs-toggle="tooltip" title="PDFs" --data-fm-label="{% trans %}PDFs{% endtrans %}" data-bs-toggle="modal" data-bs-target="#ModalDownloads">
-          <span class="material-icons-outlined">
-            file_download
-          </span>
-        </a>
-        <a href="javascript:;" data-bs-toggle="modal" data-bs-target="#metric_modal_id" class="scielo__floatingMenuItem fm-button-child item-metrics d-none d-sm-inline-block" --data-bs-toggle="tooltip" title="Métricas" --data-fm-label="{% trans %}Métricas{% endtrans %}" target="_blank">
-          <span class="material-icons-outlined">
-            show_chart
-          </span>
-        </a>
-        <ul class="scielo__floatingMenu fm-slidein" data-fm-toogle="hover">
-          <li class="fm-wrap">
-            <a href="javascript:;" class="fm-button-main"><span class="material-icons-outlined material-icons-outlined-menu-default">more_horiz</span><span class="material-icons-outlined material-icons-outlined-menu-close">close</span></a>
-            
-            <!-- exibe em tudo menos mobile-->
-            <ul class="fm-list d-none d-sm-block">
-              <li>
-                <a class="fm-button-child" --data-bs-toggle="tooltip" title="Figuras e tabelas" data-mobile-tooltip="Figuras e tabelas" data-bs-toggle="modal" data-bs-target="#ModalTablesFigures">
-                  <span class="material-icons-outlined">
-                    image
-                  </span>
-                </a>
-              </li>
-              <li>
-                <a class="fm-button-child" --data-bs-toggle="tooltip" title="Versões e traduções" data-mobile-tooltip="Versões e traduções" data-bs-toggle="modal" data-bs-target="#ModalVersionsTranslations">
-                  <span class="material-icons-outlined">
-                    translate
-                  </span>
-                </a>
-              </li>
-              <li>
-                <a class="fm-button-child" --data-bs-toggle="tooltip" title="Como citar este artigo" data-mobile-tooltip="Como citar este artigo" data-bs-toggle="modal" data-bs-target="#ModalHowcite">
-                  <span class="material-icons-outlined">
-                    link
-                  </span>
-                </a>
-              </li>
-              <li>
-                <a class="fm-button-child" --data-bs-toggle="tooltip" title="Artigos relacionados" data-mobile-tooltip="Artigos relacionados" data-bs-toggle="modal" data-bs-target="#ModalRelatedArticles">
-                  <span class="material-icons-outlined">
-                    article
-                  </span>
-                </a>
-              </li>
-            </ul>
-      
-      
-            <!-- exibe apenas no mobile-->
-            <ul class="fm-list d-block d-sm-none">
-              <li class="">
-                <a class="fm-button-child item-goto" data-bs-toggle="tooltip" title="Ir para o topo" data-mobile-tooltip="Ir para o topo" href="#top">
-                  <span class="material-icons-outlined">
-                    vertical_align_top
-                  </span>
-                </a>
-              </li>
-              <li class="d-block d-sm-none">
-                <a href="javascript:;" class="fm-button-child item-download" data-bs-toggle="tooltip" title="PDFs" data-mobile-tooltip="PDFs" data-bs-toggle="modal" data-target="#ModalDownloads">
-                  <span class="material-icons-outlined">
-                    file_download
-                  </span>
-                </a>
-              </li>
-              <li class="d-block d-sm-none">
-                <a href="javascript:;" data-toggle="modal" data-target="#metric_modal_id" class="fm-button-child item-metrics" data-bs-toggle="tooltip" title="Métricas" data-mobile-tooltip="Métricas" target="_blank">
-                  <span class="material-icons-outlined">
-                    show_chart
-                  </span>
-                </a>
-              </li>
-              <li>
-                <a class="fm-button-child" data-bs-toggle="tooltip" title="Figuras e tabelas" data-mobile-tooltip="Figuras e tabelas" data-toggle="modal" data-bs-target="#ModalTablesFigures">
-                  <span class="material-icons-outlined">
-                    image
-                  </span>
-                </a>
-              </li>
-              <li>
-                <a class="fm-button-child" data-bs-toggle="tooltip" title="Versões e traduções" data-mobile-tooltip="Versões e traduções" data-toggle="modal" data-bs-target="#ModalVersionsTranslations">
-                  <span class="material-icons-outlined">
-                    translate
-                  </span>
-                </a>
-              </li>
-              <li>
-                <a class="fm-button-child" data-bs-toggle="tooltip" title="Como citar este artigo" data-mobile-tooltip="Como citar este artigo" data-toggle="modal" data-bs-target="#ModalArticles">
-                  <span class="material-icons-outlined">
-                    link
-                  </span>
-                </a>
-              </li>
-              <li>
-                <a class="fm-button-child" data-bs-toggle="tooltip" title="Artigos relacionados" data-mobile-tooltip="Artigos relacionados" data-toggle="modal" data-bs-target="#ModalRelatedArticles">
-                  <span class="material-icons-outlined">
-                    article
-                  </span>
-                </a>
-              </li>
-            </ul>
-      
-      
-      
-          </li>
-        </ul>
-      </div>
+<div class="row">
+  <div class="col">
+
+    <div class="scielo__floatingMenuCttJs3">
+      <a class="scielo__floatingMenuItem fm-button-child item-goto d-none d-lg-inline-block" data-bs-toggle="tooltip" title="{% trans %}Ir para o topo{% endtrans %}" href="#top">
+        <span class="material-icons-outlined">
+          vertical_align_top
+        </span>
+      </a>
+      <a href="javascript:;" class="scielo__floatingMenuItem fm-button-child item-download d-none d-lg-inline-block" data-bs-toggle="tooltip" title="{% trans %}PDFs{% endtrans %}" data-bs-target="#ModalDownloads" tabindex="0">
+        <span class="material-icons-outlined">
+          file_download
+        </span>
+      </a>
+      <a href="javascript:;" class="scielo__floatingMenuItem fm-button-child item-metrics d-none d-lg-inline-block" data-bs-toggle="tooltip" title="{% trans %}Métricas{% endtrans %}" target="_blank" data-bs-target="#metric_modal_id" tabindex="0">
+        <span class="material-icons-outlined">
+          show_chart
+        </span>
+      </a>
+      <ul class="scielo__floatingMenuJs3 fm-slidein" data-fm-toogle="hover">
+        <li class="fm-wrap">
+          <a href="javascript:;" class="fm-button-main" data-bs-toggle="tooltip" title="{% trans %}Abrir menu{% endtrans %}" tabindex="0"><span class="material-icons-outlined material-icons-outlined-menu-default">more_horiz</span></a>
+          <a href="javascript:;" class="fm-button-close" data-bs-toggle="tooltip" title="{% trans %}Fechar menu{% endtrans %}" tabindex="0"><span class="material-icons-outlined material-icons-outlined-menu-close">close</span></a>
+
+          <!-- exibe em tudo menos mobile-->
+          <ul class="fm-list-desktop d-none d-lg-block">
+            <li>
+              <a class="fm-button-child" id="lnkFigsTables" data-bs-toggle="tooltip" title="{% trans %}Figuras e tabelas{% endtrans %}" data-bs-target="#ModalTablesFigures" tabindex="0">
+                <span class="material-icons-outlined">
+                  image
+                </span>
+              </a>
+            </li>
+            <li>
+              <a class="fm-button-child" id="lnkVersTranslations" data-bs-toggle="tooltip" title="{% trans %}Versões e traduções{% endtrans %}" data-bs-target="#ModalVersionsTranslations" tabindex="0">
+                <span class="material-icons-outlined">
+                  translate
+                </span>
+              </a>
+            </li>
+            <li>
+              <a class="fm-button-child" id="lnkHowToCite" data-bs-toggle="tooltip" title="{% trans %}Como citar este artigo{% endtrans %}" data-bs-target="#ModalHowcite" tabindex="0">
+                <span class="material-icons-outlined">
+                  link
+                </span>
+              </a>
+            </li>
+            <li>
+              <a class="fm-button-child" id="lnkArticles" data-bs-toggle="tooltip" title="{% trans %}Artigos relacionados{% endtrans %}" data-bs-target="#ModalRelatedArticles" tabindex="0">
+                <span class="material-icons-outlined">
+                  article
+                </span>
+              </a>
+            </li>
+          </ul>
+
+
+
+          <!-- exibe apenas no mobile-->
+          <ul class="fm-list-mobile d-block d-xl-none">
+            <li class="">
+              <a class="fm-button-child item-goto" data-mobile-tooltip="{% trans %}Ir para o topo{% endtrans %}" href="#top">
+                <span class="material-icons-outlined">
+                  vertical_align_top
+                </span>
+              </a>
+            </li>
+            <li class="">
+              <a href="javascript:;" class="fm-button-child item-download" data-mobile-tooltip="{% trans %}PDFs{% endtrans %}" data-bs-toggle="modal" data-bs-target="#ModalDownloads">
+                <span class="material-icons-outlined">
+                  file_download
+                </span>
+              </a>
+            </li>
+            <li class="">
+              <a href="javascript:;" class="fm-button-child item-metrics" data-mobile-tooltip="{% trans %}Métricas{% endtrans %}" data-bs-toggle="modal" data-bs-target="#metric_modal_id">
+                <span class="material-icons-outlined">
+                  show_chart
+                </span>
+              </a>
+            </li>
+            <li class="">
+              <a class="fm-button-child" data-mobile-tooltip="{% trans %}Figuras e tabelas{% endtrans %}" data-bs-toggle="modal" data-bs-target="#ModalTablesFigures">
+                <span class="material-icons-outlined">
+                  image
+                </span>
+              </a>
+            </li>
+            <li class="">
+              <a class="fm-button-child" data-mobile-tooltip="{% trans %}Versões e traduções{% endtrans %}" data-bs-toggle="modal" data-bs-target="#ModalVersionsTranslations">
+                <span class="material-icons-outlined">
+                  translate
+                </span>
+              </a>
+            </li>
+            <li class="">
+              <a class="fm-button-child" data-mobile-tooltip="{% trans %}Como citar este artigo{% endtrans %}" data-bs-toggle="modal" data-bs-target="#ModalHowcite">
+                <span class="material-icons-outlined">
+                  link
+                </span>
+              </a>
+            </li>
+            <li class="">
+              <a class="fm-button-child" data-mobile-tooltip="{% trans %}Artigos relacionados{% endtrans %}" data-bs-toggle="modal" data-bs-target="#ModalRelatedArticles">
+                <span class="material-icons-outlined">
+                  article
+                </span>
+              </a>
+            </li>
+          </ul>
+
+        </li>
+      </ul>
     </div>
   </div>
 </div>
-
+</div>


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona o novo menu flutuante na página do artigo.

#### Onde a revisão poderia começar?

Por commit

#### Como este poderia ser testado manualmente?

Acessando a página do artigo e verificando o comportamento pelo link: https://ramoncordini.com.br/scielo/novo-menu-flutuante/artigo/artigo-atual.html 

#### Algum cenário de contexto que queira dar?

Idealmente essa implementação deveria de ser realizada no packtools e está porém não funciona por uma questão de precedência do javascript.

### Screenshots

![Screenshot 2025-03-20 at 08 20 36](https://github.com/user-attachments/assets/0bcda365-b59b-4b13-b12b-f62064be0646)

![Screenshot 2025-03-20 at 08 20 57](https://github.com/user-attachments/assets/ff7f718c-77b3-4314-aa16-32350c03b805)


#### Quais são tickets relevantes?

Esse PR complementa o PR: https://github.com/scieloorg/opac_5/pull/241

### Referências
N/A

