### PR TITLE
Fix: Correção tradução do Menu idiomas na página do artigo. 

### DIFF
--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -1623,13 +1623,13 @@ msgstr "Text"
 #: opac/webapp/templates/article/includes/levelMenu.html:335
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:38
 msgid "Resumo "
-msgstr ""
+msgstr "Abstract"
 
 #: opac/webapp/templates/article/includes/levelMenu.html:157
 #: opac/webapp/templates/article/includes/levelMenu.html:394
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:40
 msgid "Texto "
-msgstr ""
+msgstr "Text"
 
 #: opac/webapp/templates/article/includes/levelMenu.html:179
 #: opac/webapp/templates/article/includes/levelMenu.html:199


### PR DESCRIPTION
#### O que esse PR faz?
Corrige no idioma Ingles (en) alguns termos que estavam sem tradução na interface do artigo. Veja os prints

#### Onde a revisão poderia começar?
Execute o sistema com as alterações e vá até a tela do artigo e compare com os prints aqui anexados.

#### Como este poderia ser testado manualmente?
Siga os passos descritos acima.

#### Algum cenário de contexto que queira dar?
No video que relatou o erro (https://scielo.slack.com/files/U37RV0FD3/F08CWE223A9/screenshare_-_2025-02-12_11_48_36_am.webm) apareciam versões de artigos com idiomas frances. Não foi possível testar este idioma localmente. As correções se restringem ao idioma Ingles.

### Screenshots
![Screen Shot 2025-05-08 at 18 19 45](https://github.com/user-attachments/assets/bcfed372-46ce-4a65-8a2b-75fa2a89f683)
![Screen Shot 2025-05-08 at 18 19 26](https://github.com/user-attachments/assets/68971860-8582-4582-b902-778f5088a44e)
![Screen Shot 2025-05-08 at 18 19 10](https://github.com/user-attachments/assets/8d1f6287-c79f-4111-b0da-f84e2a42be74)


#### Quais são tickets relevantes?
-

### Referências
- 

