### PR TITLE
Atualiza packtools 4.11.10 - Melhorias de acessibilidade e de apresentação no modal de autoria

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -95,5 +95,5 @@ tox==4.3.5
 PyJWT==2.8.0
 tenacity==8.2.3
 -e git+https://git@github.com/scieloorg/opac_schema@v2.9.0#egg=Opac_Schema
--e git+https://git@github.com/scieloorg/packtools@4.11.4#egg=packtools
+-e git+https://git@github.com/scieloorg/packtools@4.11.10#egg=packtools
 -e git+https://github.com/scieloorg/scieloh5m5.git@1.9.5#egg=scieloh5m5


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza packtools 4.11.10 - Melhorias de acessibilidade e de apresentação no modal de autoria

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Acessar a página de um artigo
Clicar em "AUTORIA"
Observar a diferença

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
ANTES
<img width="567" alt="Captura de Tela 2025-06-24 às 20 33 51" src="https://github.com/user-attachments/assets/160632e1-4d0c-4b7f-ae1d-ba6694fa140b" />

DEPOIS
<img width="342" alt="Captura de Tela 2025-06-24 às 20 34 04" src="https://github.com/user-attachments/assets/f75b8db5-fa6e-4dd2-bccd-a076d7a559ea" />

#### Quais são tickets relevantes?
https://github.com/scieloorg/packtools/pull/978

### Referências
n/a
