### PR TITLE
Correções de validação e tratamento de dados de journal e issue nos controllers e factory de journal

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -675,13 +675,14 @@ def get_issues_by_jid(jid, **kwargs):
                     Empty list if no public articles found.
     """
     article_issue_ids = Article.objects(journal=jid, is_public=True).distinct("issue")
-    if not article_issue_ids:
-        return []
+    params = {}
+    if article_issue_ids:
+        params["iid__in"] = [item.iid for item in article_issue_ids]
 
     return Issue.objects(
         journal=jid,
-        iid__in=[item.iid for item in article_issue_ids],
         is_public=True,
+        **params,
     ).order_by("-year", "-order")
 
 
@@ -832,7 +833,7 @@ def set_last_issue_and_issue_count(journal, last_issue=None, issue_count=None):
         journal.issue_count = issue_count
         save = True
 
-    if journal.last_issue.url_segment != last_issue.url_segment:
+    if not journal.last_issue or journal.last_issue.url_segment != last_issue.url_segment:
         journal.last_issue = LastIssue(
             volume=last_issue.volume,
             number=last_issue.number,

--- a/opac/webapp/factory.py
+++ b/opac/webapp/factory.py
@@ -41,7 +41,7 @@ def JournalFactory(data):
     journal.metrics = models.JounalMetrics(**metadata.get("metrics", {}))
 
     # Issue count
-    journal.issue_count =  data.get("issue_count") or len(data.get("items", []))
+    journal.issue_count =  data.get("issue_count") or len(data.get("items") or [])
 
     # Mission
     journal.mission = [
@@ -82,8 +82,9 @@ def JournalFactory(data):
 
     journal.online_submission_url = metadata.get("online_submission_url", "")
 
-    if "missing" in journal.logo_url or not journal.logo_url:
+    if not journal.logo_url or "missing" in journal.logo_url:
         journal.logo_url = metadata.get("logo_url")
+
     journal.current_status = metadata.get("current_status")
 
     timelines = []


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request corrige problemas críticos de validação e tratamento de dados que estavam causando erros de execução na aplicação. Especificamente:

- **Corrige erro de AttributeError** quando `journal.last_issue` é `None` no método `set_last_issue_and_issue_count`
- **Previne TypeError** na função `get_issues_by_jid` quando não há artigos públicos disponíveis
- **Resolve erro de len() em NoneType** no `JournalFactory` quando `data.get('items')` retorna `None`
- **Melhora a robustez** das consultas ao banco de dados com parâmetros condicionais

#### Onde a revisão poderia começar?
A revisão deve começar pelos seguintes arquivos na ordem sugerida:

1. **`opac/webapp/controllers.py`** - Linhas 677-686 e 835-841
   - Verificar a lógica condicional na função `get_issues_by_jid`
   - Analisar a verificação de `journal.last_issue` antes do acesso aos atributos

2. **`opac/webapp/factory.py`** - Linhas 44 e 85-86
   - Revisar o tratamento de `None` em `data.get('items')`
   - Verificar a reordenação da validação de `logo_url`

#### Como este poderia ser testado manualmente?
Problemas encontrados ao publicar journal no opac_5 e este journal não tem issues nem articles, que causavam erro ao ingressar dados de journal. Além disso, algumas páginas como grade e sumário apresentavam erro 500 devido à ausência de dados no lugar de apresentar a página padrão sem os dados.

#### Algum cenário de contexto que queira dar?
Estes erros foram identificados em ambiente de desenvolvimento onde:

- **Journals novos** podem não ter `last_issue` definido inicialmente
- **Consultas de issues** podem retornar listas vazias quando não há artigos públicos
- **Dados de entrada** do factory podem conter valores `None` em campos opcionais

As correções implementam **programação defensiva** para garantir que a aplicação continue funcionando mesmo com dados incompletos ou em estados intermediários de criação.

### Screenshots
não foi capturadas as telas com os erros

#### Quais são tickets relevantes?
- AttributeError ao acessar journal.last_issue quando é None
- TypeError em get_issues_by_jid com journals sem artigos públicos  
- Erro de len() em NoneType no JournalFactory

### Referências
n/a