### PR TITLE
Adiciona suporte para DarkVisitors Analytics

### DIFF
--- a/.envs/.production-template/.flask
+++ b/.envs/.production-template/.flask
@@ -230,3 +230,8 @@ SCIMAGO_URL_IR=https://www.scimagoir.com/
 # ---------------------------------------------------
 # string with the default mathjax URL; ex: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS-MML_HTMLorMML"
 OPAC_MATHJAX_CDN_URL=https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS-MML_HTMLorMML
+
+# -------------------- darkvisitors.com -------------
+# ---------------------------------------------------
+OPAC_ANALYTICS_AGENT_DARKVISITORS_ENABLED=False
+OPAC_ANALYTICS_AGENT_DARKVISITORS_PROJECT_KEY=PROJECT_KEY

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -685,3 +685,8 @@ SITE_LICENSE_NAME = os.environ.get("OPAC_SITE_LICENSE_NAME") or "Creative Common
 SITE_LICENSE_URL = os.environ.get("OPAC_SITE_LICENSE_URL") or "https://creativecommons.org/licenses/by/4.0/"
 SITE_LICENSE_IMG_URL = os.environ.get("OPAC_SITE_LICENSE_IMG_URL") or "https://licensebuttons.net/l/by/4.0/88x31.png"
 SITE_LICENSE_IMG_MINI_URL = os.environ.get("OPAC_SITE_LICENSE_IMG_MINI_URL") or "https://licensebuttons.net/l/by/4.0/80x15.png"
+
+# Lê a variável e compara com 'True', 'true', '1', etc.
+ANALYTICS_AGENT_DARKVISITORS_ENABLED = os.environ.get('OPAC_ANALYTICS_AGENT_DARKVISITORS_ENABLED', 'False').lower() in ('true', '1', 't', 'yes', 'y')
+ANALYTICS_AGENT_DARKVISITORS_PROJECT_KEY = os.environ.get("OPAC_ANALYTICS_AGENT_DARKVISITORS_PROJECT_KEY")
+

--- a/opac/webapp/templates/base.html
+++ b/opac/webapp/templates/base.html
@@ -38,6 +38,10 @@
       <!-- End Google Analytics -->
     {% endif %}
 
+    {% if config.ANALYTICS_AGENT_DARKVISITORS_ENABLED and config.ANALYTICS_AGENT_DARKVISITORS_PROJECT_KEY %}
+    <script src="https://darkvisitors.com/tracker.js?project_key={{ config.ANALYTICS_AGENT_DARKVISITORS_PROJECT_KEY }}"></script>
+    {% endif %}
+
     {% block extra_css %}{% endblock %}
 
   </head>


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona integração com o serviço DarkVisitors Analytics, permitindo monitoramento de tráfego de bots e agentes automatizados. A funcionalidade pode ser habilitada/desabilitada via variáveis de ambiente.

#### Onde a revisão poderia começar?
Começar pela configuração em `opac/webapp/config/default.py` (linhas 689-691) onde são definidas as variáveis de configuração com conversão booleana.

#### Como este poderia ser testado manualmente?
1. Definir as variáveis de ambiente:
   ```bash
   export OPAC_ANALYTICS_AGENT_DARKVISITORS_ENABLED=true
   export OPAC_ANALYTICS_AGENT_DARKVISITORS_PROJECT_KEY=sua-chave-aqui
   ```
2. Iniciar a aplicação Flask
3. Acessar qualquer página e inspecionar o HTML
4. Verificar se o script `https://darkvisitors.com/tracker.js` está presente no `<head>`
5. Testar com `ENABLED=false` para confirmar que o script não é incluído

#### Algum cenário de contexto que queira dar?
O DarkVisitors é um serviço que identifica e monitora bots, crawlers e agentes automatizados que acessam o site. Isso permite entender melhor o tráfego não-humano e potencialmente bloquear bots indesejados. A implementação segue o padrão já existente para Google Analytics.

### Screenshots
N/A - Alteração não visual, apenas inclusão de script no HTML.

#### Quais são tickets relevantes?
Resolve #319

### Referências
- [[DarkVisitors Documentation](https://darkvisitors.com/docs)](https://darkvisitors.com/docs)
- Implementação similar do Google Analytics no projeto (linhas 35-38 em `base.html`)