### PR TITLE
Feat: Cria campos no formulário de Pages para referênciar páginas e navegação entre páginas Pais e Filhas

### DIFF
--- a/opac/webapp/config/lang_names.py
+++ b/opac/webapp/config/lang_names.py
@@ -194,9 +194,181 @@ LANG_NAMES = {
 }
 
 
+LANGS_FALLBACK = {
+    "pt_BR": {
+        "de": "Alemão",
+        "fr": "Francês",
+        "ru": "Russo",
+        "zh": "Chinês",
+        "zh-Hans": "Chinês",
+        "zh-Hant": "Chinês",
+        "it": "Italiano",
+        "en": "Inglês",
+        "pt": "Português",
+        "es": "Espanhol",
+        "af": "Afrikaans",  # às vezes "Africâner"
+        "nso": "Lamnso",
+        "ar": "Árabe",
+        "eu": "Basco/Eusquera",
+        "bg": "Búlgaro",
+        "ca": "Catalão",
+        "cs": "Tcheco",
+        "da": "Dinamarquês",
+        "nl": "Neerlandês/Holandês",
+        "eo": "Esperanto",
+        "gl": "Galego",
+        "gr": "Grego",  # considere usar "el"
+        "he": "Hebraico",
+        "hi": "Hindi",
+        "hu": "Húngaro",
+        "in": "Indonésio",  # considere usar "id"
+        "ia": "Interlíngua",
+        "ie": "Interlíngue",
+        "ja": "Japonês",
+        "ko": "Coreano",
+        "la": "Latim",
+        "no": "Norueguês",
+        "pl": "Polonês",
+        "ro": "Romeno",
+        "sa": "Sânscrito",
+        "sh": "Servo-croata",
+        "sk": "Eslovaco",
+        "sn": "Esloveno",
+        "sv": "Sueco",
+        "tr": "Turco",
+        "uk": "Ucraniano",
+        "ur": "Urdu",
+        "zz": "Outro",
+        # opcionais ISO modernos (espelho de chaves alternativas)
+        "el": "Grego",      # alternativo a "gr"
+        "id": "Indonésio",  # alternativo a "in"
+        "nb": "Norueguês (Bokmål)",
+        "nn": "Norueguês (Nynorsk)",
+        "sr": "Sérvio",
+        "hr": "Croata",
+        "bs": "Bósnio",
+    },
+    "en": {
+        "de": "German",
+        "fr": "French",
+        "ru": "Russian",
+        "zh": "Chinese",
+        "zh-Hans": "Chinese",
+        "zh-Hant": "Chinese",
+        "it": "Italian",
+        "en": "English",
+        "pt": "Portuguese",
+        "es": "Spanish",
+        "af": "Afrikaans",
+        "nso": "Lamnso",
+        "ar": "Arabic",
+        "eu": "Basque",
+        "bg": "Bulgarian",
+        "ca": "Catalan",
+        "cs": "Czech",
+        "da": "Danish",
+        "nl": "Dutch",
+        "eo": "Esperanto",
+        "gl": "Galician",
+        "gr": "Greek",  # consider "el"
+        "he": "Hebrew",
+        "hi": "Hindi",
+        "hu": "Hungarian",
+        "in": "Indonesian",  # consider "id"
+        "ia": "Interlingua",
+        "ie": "Interlingue",
+        "ja": "Japanese",
+        "ko": "Korean",
+        "la": "Latin",
+        "no": "Norwegian",
+        "pl": "Polish",
+        "ro": "Romanian",
+        "sa": "Sanskrit",
+        "sh": "Serbo-Croat",
+        "sk": "Slovak",
+        "sn": "Slovenian",
+        "sv": "Swedish",
+        "tr": "Turkish",
+        "uk": "Ukrainian",
+        "ur": "Urdu",
+        "zz": "Other",
+        "el": "Greek",      # mirror for "gr"
+        "id": "Indonesian", # mirror for "in"
+        "nb": "Norwegian (Bokmål)",
+        "nn": "Norwegian (Nynorsk)",
+        "sr": "Serbian",
+        "hr": "Croatian",
+        "bs": "Bosnian",
+    },
+    "es": {
+        "de": "Alemán",
+        "fr": "Francés",
+        "ru": "Ruso",
+        "zh": "Chino",
+        "zh-Hans": "Chino",
+        "zh-Hant": "Chino",
+        "it": "Italiano",
+        "en": "Inglés",
+        "pt": "Portugués",
+        "es": "Español",
+        "af": "Afrikaans",
+        "nso": "Lamnso",
+        "ar": "Árabe",
+        "eu": "Vasco/Euskera",
+        "bg": "Búlgaro",
+        "ca": "Catalán",
+        "cs": "Checo",
+        "da": "Danés",
+        "nl": "Neerlandés/Holandés",
+        "eo": "Esperanto",
+        "gl": "Gallego",
+        "gr": "Griego",  # considere usar "el"
+        "he": "Hebreo",
+        "hi": "Hindi",
+        "hu": "Húngaro",
+        "in": "Indonesio",  # considere "id"
+        "ia": "Interlingua",
+        "ie": "Interlingue",
+        "ja": "Japonés",
+        "ko": "Coreano",
+        "la": "Latín",
+        "no": "Noruego",
+        "pl": "Polaco",
+        "ro": "Rumano",
+        "sa": "Sánscrito",
+        "sh": "Serbocroata",
+        "sk": "Eslovaco",
+        "sn": "Esloveno",
+        "sv": "Sueco",
+        "tr": "Turco",
+        "uk": "Ucraniano",
+        "ur": "Urdu",
+        "zz": "Otro",
+        # espejos ISO modernos
+        "el": "Griego",      # espejo de "gr"
+        "id": "Indonesio",   # espejo de "in"
+        "nb": "Noruego (Bokmål)",
+        "nn": "Noruego (Nynorsk)",
+        "sr": "Serbio",
+        "hr": "Croata",
+        "bs": "Bosnio",
+    },
+}
+
+
 def get_original_lang_name(code):
     return LANG_NAMES.get(code, (None, code))[0]
 
+
+def display_lang_name_fallback(locale, code):
+    lang = None
+    try:
+        lang = LANGS_FALLBACK.get(locale, {}).get(str(code).lower())
+    except:
+        return code
+    finally:
+        return lang or code
+    
 
 def display_original_lang_name(code):
     name = get_original_lang_name(code)

--- a/opac/webapp/config/lang_names.py
+++ b/opac/webapp/config/lang_names.py
@@ -356,25 +356,16 @@ LANGS_FALLBACK = {
 }
 
 
+LANGS_FALLBACK_NORMALIZED = {
+    str(locale).lower(): {str(k).lower(): v for k, v in mapping.items()}
+    for locale, mapping in LANGS_FALLBACK.items()
+}
+
 def get_original_lang_name(code):
     return LANG_NAMES.get(code, (None, code))[0]
 
-
 def display_lang_name_fallback(locale, code):
-    lang = None
-    try:
-        lang = LANGS_FALLBACK.get(locale, {}).get(str(code).lower())
-    except:
-        return code
-    finally:
-        return lang or code
-    
-
-def display_original_lang_name(code):
-    name = get_original_lang_name(code)
-    if name is None:
-        return code
-    name = name.capitalize()
-    if "," in name:
-        return name.split(",")[0]
-    return name
+    locale_key = str(locale).lower() if locale is not None else ""
+    code_key = str(code).lower() if code is not None else ""
+    lang = LANGS_FALLBACK_NORMALIZED.get(locale_key, {}).get(code_key)
+    return lang or code

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1748,6 +1748,12 @@ def get_page_by_slug_name(slug_name, lang=None, is_draft=False):
     return Pages.objects(language=lang, slug_name=slug_name, is_draft=is_draft).first()
 
 
+def get_page_about_root(lang, is_draft=False):
+    return Pages.objects(language=lang, journal="", is_draft=is_draft, parent_page=None, page_type__ne="free")
+
+def get_free_page_by_slug(slug, lang):
+    return Pages.objects(slug_name=slug, is_draft=False, page_type="free", language=lang)
+
 def related_links(article):
     expr = []
     if article.title or article.section:

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1751,8 +1751,8 @@ def get_page_by_slug_name(slug_name, lang=None, is_draft=False):
 def get_page_about_root(lang, is_draft=False):
     return Pages.objects(language=lang, journal="", is_draft=is_draft, parent_page=None, page_type__ne="free")
 
-def get_free_page_by_slug(slug, lang):
-    return Pages.objects(slug_name=slug, is_draft=False, page_type="free", language=lang)
+def get_free_page_by_slug(slug, lang, is_draft=False):
+    return Pages.objects(slug_name=slug, is_draft=is_draft, page_type="free", language=lang).first()
 
 def related_links(article):
     expr = []

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -323,27 +323,45 @@ def collection_list_feed():
     return feed.get_response()
 
 
+
+@main.route("/about/<path:slug_name>", methods=["GET"])
+def page_about_detail(slug_name):
+    language = session.get("lang", get_locale())
+    page = controllers.get_page_by_slug_about(slug_name, lang=language, is_draft=False)
+    
+    if not page:
+        abort(404, _("Página não encontrada"))
+    breadcrumbs = utils.build_breadcrumbs(page)
+    children = utils.get_children_in_order(page)
+    context = {
+        "children": children,
+        "breadcrumbs": breadcrumbs,
+        "page": page,
+    }
+    return render_template("collection/about_detail.html", **context)
+
+
 @main.route("/about/", methods=["GET"])
-@main.route("/about/<string:slug_name>", methods=["GET"])
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
-def about_collection(slug_name=None):
+def about_collection():
     language = session.get("lang", get_locale())
 
     context = {}
-    page = None
-    if slug_name:
-        # caso seja uma página
-        page = controllers.get_page_by_slug_name(slug_name, language)
-        if not page:
-            abort(404, _("Página não encontrada"))
-        context["page"] = page
-    else:
-        # caso não seja uma página é uma lista
-        pages = controllers.get_pages_by_lang(language)
-        context["pages"] = pages
+    pages = controllers.get_page_about_root(language)
 
+    context["pages"] = pages.order_by("order")
     return render_template("collection/about.html", **context)
 
+
+@main.route("/free/<string:slug_name>", methods=["GET"])
+def free_page(slug_name):
+    language = session.get("lang", get_locale())
+    page = controllers.get_free_page_by_slug(slug_name, lang=language, is_draft=False)
+    
+    if not page:
+        abort(404, _("Página não encontrada"))
+
+    return render_template("collection/about_detail.html", page=page)
 
 # ###################################Journal#####################################
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -33,7 +33,7 @@ from packtools import HTMLGenerator
 from webapp import babel, cache, controllers, forms
 from webapp.choices import STUDY_AREAS
 from webapp.controllers import create_press_release_record
-from webapp.config.lang_names import display_original_lang_name
+from webapp.config.lang_names import display_original_lang_name, display_lang_name_fallback
 from webapp.utils import utils
 from webapp.utils.caching import cache_key_with_lang, cache_key_with_lang_with_qs
 from webapp.main.errors import page_not_found, internal_server_error
@@ -1281,12 +1281,13 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
             logger.exception(exc)
 
             abort(500, _("Erro inesperado"))
+        language = session.get("lang", get_locale())
 
         text_versions = sorted(
             [
                 (
                     lang,
-                    display_original_lang_name(lang),
+                    display_lang_name_fallback(locale=language, code=lang),
                     url_for(
                         "main.article_detail_v3",
                         url_seg=article.journal.url_segment,

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -327,12 +327,12 @@ def collection_list_feed():
 @main.route("/about/<path:slug_name>", methods=["GET"])
 def page_about_detail(slug_name):
     language = session.get("lang", get_locale())
-    page = controllers.get_page_by_slug_about(slug_name, lang=language, is_draft=False)
+    page = controllers.get_page_by_slug_name(slug_name, lang=language, is_draft=False)
     
     if not page:
         abort(404, _("Página não encontrada"))
     breadcrumbs = utils.build_breadcrumbs(page)
-    children = utils.get_children_in_order(page)
+    children = page.get_children()
     context = {
         "children": children,
         "breadcrumbs": breadcrumbs,

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -332,9 +332,7 @@ def page_about_detail(slug_name):
     if not page:
         abort(404, _("Página não encontrada"))
     breadcrumbs = utils.build_breadcrumbs(page)
-    children = page.get_children()
     context = {
-        "children": children,
         "breadcrumbs": breadcrumbs,
         "page": page,
     }

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -33,7 +33,7 @@ from packtools import HTMLGenerator
 from webapp import babel, cache, controllers, forms
 from webapp.choices import STUDY_AREAS
 from webapp.controllers import create_press_release_record
-from webapp.config.lang_names import display_original_lang_name, display_lang_name_fallback
+from webapp.config.lang_names import display_lang_name_fallback
 from webapp.utils import utils
 from webapp.utils.caching import cache_key_with_lang, cache_key_with_lang_with_qs
 from webapp.main.errors import page_not_found, internal_server_error

--- a/opac/webapp/templates/article/includes/levelMenu_abstracts.html
+++ b/opac/webapp/templates/article/includes/levelMenu_abstracts.html
@@ -12,7 +12,7 @@
         {% elif abstract['language'] == 'pt' %}
         (PT)
         {% else %}
-          {{ abstract['language'] }}
+          ({{ abstract['language']|upper }})
         {% endif %}
       {% endif %}
     {% endfor %}

--- a/opac/webapp/templates/article/includes/levelMenu_pdf.html
+++ b/opac/webapp/templates/article/includes/levelMenu_pdf.html
@@ -15,7 +15,7 @@
                     {% elif pdf.lang == 'pt' %}
                       {% trans %}Download PDF (Português){% endtrans %}
                     {% else %}
-                      {{ pdf.lang }}
+                      Download PDF ({{ pdf.lang }})
                     {% endif %}
                   </a>
                 </li>

--- a/opac/webapp/templates/article/includes/levelMenu_texts.html
+++ b/opac/webapp/templates/article/includes/levelMenu_texts.html
@@ -13,7 +13,7 @@
             {% elif lang == 'pt' %}
               (PT)
             {% else %} 
-              ({{ text_lang }})
+              ({{ text_lang|upper }})
             {% endif %}
           {% endif %}
         {% endfor %}

--- a/opac/webapp/templates/collection/about.html
+++ b/opac/webapp/templates/collection/about.html
@@ -6,9 +6,7 @@
 
 <section class="collection collectionAbout">
     <div class="container">
-       
         {% if pages %}
-
             <div class="row">
                 <div class="col">
 
@@ -22,34 +20,7 @@
                 </div>
             </div>
 
-        {% endif %}
-
-        {% if page %}
-            <div class="row">
-                <div class="col-12">
-                    <h1 class="h4">{{ page }}</h1>
-    
-                    {%- if page.content -%}
-                        {{ page.content|safe }}
-                    {%- else -%}
-                        {% trans %} Conteúdo não cadastrado {% endtrans %}
-                    {%- endif -%}
-                </div>
-            </div>
-
-            {% with page_updated_at=page.updated_at  %}
-            <div class="row">
-                <div class="col">
-                    {% include "includes/page_updated_at_info.html" %}
-                </div>
-            </div>
-            {% endwith %}
-        {% endif %}
-    
-        {% if page %}
-        
-    {% endif %}
-        
+        {% endif %}        
     </div>
 </section>
 

--- a/opac/webapp/templates/collection/about_detail.html
+++ b/opac/webapp/templates/collection/about_detail.html
@@ -6,23 +6,6 @@
 
 <section class="collection collectionAbout">
     <div class="container">
-       
-        {% if pages %}
-
-            <div class="row">
-                <div class="col">
-
-                    <h1 class="h4 pt-1 mb-4"> {% trans %}Sobre o SciELO{% endtrans %} {{ coll_macro.get_collection_name() }}</h1>
-                    
-                    <div class="about">
-                        {% set nodes = pages %}
-                        {% set ul_class = "networkList" %}
-                        {% include "collection/includes/_page_tree.html" %}
-                    </div>
-                </div>
-            </div>
-
-        {% endif %}
 
         {% if page %}
             <div class="row">
@@ -44,6 +27,27 @@
                 </div>
             </div>
             {% endwith %}
+            {% if children or page.parent_page %}
+                <section class="child-pages">
+                <h2>{% trans %} Páginas relacionadas {% endtrans %}</h2>
+                <ul>
+                    {% if page.parent_page %}
+                        <li>
+                            <a href="{{ url_for('.page_about_detail', slug_name=page.parent_page.slug_name) }}">
+                            {{ page.parent_page.name }}
+                            </a>
+                        </li>
+                    {% endif %}
+                    {% for child in children %}
+                    <li>
+                        <a href="{{ url_for('.page_about_detail', slug_name=child.slug_name) }}">
+                        {{ child.name }}
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+                </section>
+            {% endif %}
         {% endif %}
     
         {% if page %}

--- a/opac/webapp/templates/collection/about_detail.html
+++ b/opac/webapp/templates/collection/about_detail.html
@@ -27,24 +27,28 @@
                 </div>
             </div>
             {% endwith %}
-            {% if children or page.parent_page %}
+            {% if page.get_descendants() or page.get_ancestors() %}
                 <section class="child-pages">
                 <h2>{% trans %} Páginas relacionadas {% endtrans %}</h2>
                 <ul>
                     {% if page.parent_page %}
-                        <li>
-                            <a href="{{ url_for('.page_about_detail', slug_name=page.parent_page.slug_name) }}">
-                            {{ page.parent_page.name }}
-                            </a>
-                        </li>
+                        {% for ancestor in page.get_ancestors() %}
+                            <li>
+                                <a href="{{ url_for('.page_about_detail', slug_name=ancestor.slug_name) }}">
+                                {{ ancestor.name }}
+                                </a>
+                            </li>
+                        {% endfor %}
                     {% endif %}
-                    {% for child in children %}
-                    <li>
-                        <a href="{{ url_for('.page_about_detail', slug_name=child.slug_name) }}">
-                        {{ child.name }}
-                        </a>
-                    </li>
-                    {% endfor %}
+                    {% if page.get_descendants() %}
+                        {% for descendant in page.get_descendants() %}
+                            <li>
+                                <a href="{{ url_for('.page_about_detail', slug_name=descendant.slug_name) }}">
+                                {{ descendant.name }}
+                                </a>
+                            </li>
+                        {% endfor %}
+                    {% endif %}
                 </ul>
                 </section>
             {% endif %}

--- a/opac/webapp/templates/collection/about_detail.html
+++ b/opac/webapp/templates/collection/about_detail.html
@@ -53,11 +53,7 @@
                 </section>
             {% endif %}
         {% endif %}
-    
-        {% if page %}
-        
-    {% endif %}
-        
+
     </div>
 </section>
 

--- a/opac/webapp/templates/collection/includes/_page_tree.html
+++ b/opac/webapp/templates/collection/includes/_page_tree.html
@@ -1,0 +1,14 @@
+<ul class="{{ ul_class }}">
+  {% for node in nodes %}
+    <li>
+      <a href="/about/{{ node.slug_name }}">
+        {% trans %}{{ node }}{% endtrans %}
+      </a>
+      {% if node.child_pages %}
+        {% set nodes = node.child_pages %}
+        {% set ul_class = "networkList--children" %}
+        {% include "collection/includes/_page_tree.html" %}
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>

--- a/opac/webapp/templates/collection/includes/_page_tree.html
+++ b/opac/webapp/templates/collection/includes/_page_tree.html
@@ -2,7 +2,7 @@
   {% for node in nodes %}
     <li>
       <a href="{{ url_for('.page_about_detail', slug_name=node.slug_name) }}">
-        {% trans %}{{ node }}{% endtrans %}
+        {{ node }}
       </a>
       {% set child_nodes = node.get_children() %}
       {% if child_nodes %}

--- a/opac/webapp/templates/collection/includes/_page_tree.html
+++ b/opac/webapp/templates/collection/includes/_page_tree.html
@@ -1,11 +1,12 @@
 <ul class="{{ ul_class }}">
   {% for node in nodes %}
     <li>
-      <a href="/about/{{ node.slug_name }}">
+      <a href="{{ url_for('.page_about_detail', slug_name=node.slug_name) }}">
         {% trans %}{{ node }}{% endtrans %}
       </a>
-      {% if node.child_pages %}
-        {% set nodes = node.child_pages %}
+      {% set child_nodes = node.get_children() %}
+      {% if child_nodes %}
+        {% set nodes = child_nodes %}
         {% set ul_class = "networkList--children" %}
         {% include "collection/includes/_page_tree.html" %}
       {% endif %}

--- a/opac/webapp/templates/collection/includes/levelMenu.html
+++ b/opac/webapp/templates/collection/includes/levelMenu.html
@@ -12,6 +12,11 @@
           <ol class="breadcrumb mb-0 ps-0">
               <li class="breadcrumb-item"><a href="{{ url_for('.index') }}" alt="{% trans %}Home{% endtrans %}"><span class="material-icons-outlined">home</span></a></li>
               <li class="breadcrumb-item"><a href="{{ url_for('.about_collection') }}">{% trans %}Sobre o SciELO{% endtrans %} {{ coll_macro.get_collection_name() }}</a></li>
+                {% if breadcrumbs %}
+                  {% for breadcrumb in breadcrumbs %}
+                    <li class="breadcrumb-item"><a href="{{ url_for('.page_about_detail', slug_name=breadcrumb.slug_name) }}">{{ breadcrumb.name }}</a></li>
+                  {% endfor %}
+                {% endif %}
               <li class="breadcrumb-item">{{ page }}</li>
           </ol>
   
@@ -65,6 +70,11 @@
           <ol class="breadcrumb mb-0 ps-0">
               <li class="breadcrumb-item"><a href="{{ url_for('.index') }}" alt="{% trans %}Home{% endtrans %}"><span class="material-icons-outlined">home</span></a></li>
               <li class="breadcrumb-item"><a href="{{ url_for('.about_collection') }}">{% trans %}Sobre o SciELO{% endtrans %} {{ coll_macro.get_collection_name() }}</a></li>
+              {% if breadcrumbs %}
+                {% for breadcrumb in breadcrumbs %}
+                  <li class="breadcrumb-item"><a href="{{ url_for('.page_about_detail', slug_name=breadcrumb.slug_name) }}">{{ breadcrumb.name }}</a></li>
+                {% endfor %}
+              {% endif %}
               <li class="breadcrumb-item">{{ page }}</li>
           </ol>
   

--- a/opac/webapp/templates/journal/detail.html
+++ b/opac/webapp/templates/journal/detail.html
@@ -65,14 +65,14 @@
             <div class="col-12 col-lg-6">
               
                 {% if journal.last_issue.cover_url %}
-                <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}">
+                <a href="#">
                   <img src="{{ latest_issue.cover_url }}" class="image" alt="{% trans %}Capa do número mais recente{% endtrans %}" /> <!-- a imagem é opcional -->
                 </a>
                 {% endif %}
                 <span class="text">
                   <strong><small>{% trans %}Número mais recente{% endtrans %}</small></strong>
                   <p>
-                    <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}">
+                    <a href="#">
                     <strong>{{ latest_issue_legend|default('--', True) }}</strong>
                     </a>
                   </p>
@@ -83,7 +83,7 @@
                 <h3>{% trans %}Sumário{% endtrans %}</h3>
                 <ul>
                   {% for section in sections %}
-                    <li><a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}#{{ section|upper }}">{{ section }}</a></li>
+                    <li><a href="##{{ section|upper }}">{{ section }}</a></li>
                   {% endfor %}
                 </ul>
               </div>
@@ -248,7 +248,7 @@
             <div class="col-12 col-sm-6">
               
                 {% if journal.last_issue.cover_url %}
-                <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}">
+                <a href="#">
                   <img src="{{ latest_issue.cover_url }}" class="image" alt="{% trans %}Capa do número mais recente{% endtrans %}" /> <!-- a imagem é opcional -->
                 </a>
                 {% endif %}
@@ -258,7 +258,7 @@
                   <h2 class="scielo__text-title--4">{{ latest_issue_legend|default('--', True) }}</h2>
                   -->
                   <p>
-                    <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}">
+                    <a href="#">
                     <strong>{{ latest_issue_legend|default('--', True) }}</strong>
                     </a>
                   </p>
@@ -270,7 +270,7 @@
                 <h3>{% trans %}Sumário{% endtrans %}</h3>
                 <ul>
                   {% for section in sections %}
-                    <li><a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}#{{ section|upper }}">{{ section }}</a></li>
+                    <li><a href="##{{ section|upper }}">{{ section }}</a></li>
                   {% endfor %}
                 </ul>
               </div>

--- a/opac/webapp/templates/journal/detail.html
+++ b/opac/webapp/templates/journal/detail.html
@@ -65,14 +65,14 @@
             <div class="col-12 col-lg-6">
               
                 {% if journal.last_issue.cover_url %}
-                <a href="#">
+                <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}">
                   <img src="{{ latest_issue.cover_url }}" class="image" alt="{% trans %}Capa do número mais recente{% endtrans %}" /> <!-- a imagem é opcional -->
                 </a>
                 {% endif %}
                 <span class="text">
                   <strong><small>{% trans %}Número mais recente{% endtrans %}</small></strong>
                   <p>
-                    <a href="#">
+                    <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}">
                     <strong>{{ latest_issue_legend|default('--', True) }}</strong>
                     </a>
                   </p>
@@ -83,7 +83,7 @@
                 <h3>{% trans %}Sumário{% endtrans %}</h3>
                 <ul>
                   {% for section in sections %}
-                    <li><a href="##{{ section|upper }}">{{ section }}</a></li>
+                    <li><a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}#{{ section|upper }}">{{ section }}</a></li>
                   {% endfor %}
                 </ul>
               </div>
@@ -248,7 +248,7 @@
             <div class="col-12 col-sm-6">
               
                 {% if journal.last_issue.cover_url %}
-                <a href="#">
+                <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}">
                   <img src="{{ latest_issue.cover_url }}" class="image" alt="{% trans %}Capa do número mais recente{% endtrans %}" /> <!-- a imagem é opcional -->
                 </a>
                 {% endif %}
@@ -258,7 +258,7 @@
                   <h2 class="scielo__text-title--4">{{ latest_issue_legend|default('--', True) }}</h2>
                   -->
                   <p>
-                    <a href="#">
+                    <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}">
                     <strong>{{ latest_issue_legend|default('--', True) }}</strong>
                     </a>
                   </p>
@@ -270,7 +270,7 @@
                 <h3>{% trans %}Sumário{% endtrans %}</h3>
                 <ul>
                   {% for section in sections %}
-                    <li><a href="##{{ section|upper }}">{{ section }}</a></li>
+                    <li><a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}#{{ section|upper }}">{{ section }}</a></li>
                   {% endfor %}
                 </ul>
               </div>

--- a/opac/webapp/templates/journal/includes/levelMenu.html
+++ b/opac/webapp/templates/journal/includes/levelMenu.html
@@ -46,11 +46,11 @@
 
           {# Atual #}
           {% if not next_item and last_issue %}
-            <a title="{% trans %}número atual{% endtrans %}" href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}" class="btn {{ mmenu.endpoint_selected(view_name='main.issue_grid') }} {% if not 'grid' in request.url_rule.rule %} active {% else %} unselected {% endif %}{% if mmenu.endpoint_selected(view_name='main.journal_detail') %} unselected {% endif %}">
+            
               {% trans %}Número atual{% endtrans %}
             </a>
           {% else %}
-            <a title="{% trans %}número atual{% endtrans %}" href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}" class="btn">
+            <a title="{% trans %}número atual{% endtrans %}" href="#" class="btn">
               {% trans %}Número atual{% endtrans %}
             </a>
           {% endif %}
@@ -140,7 +140,7 @@
 
           {# Atual #}
           {% if last_issue %}
-            <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}" class="btn btn-secondary">
+            <a href="#" class="btn btn-secondary">
               {% trans %}Atual{% endtrans %}
             </a>
           {% endif %}

--- a/opac/webapp/templates/journal/includes/levelMenu.html
+++ b/opac/webapp/templates/journal/includes/levelMenu.html
@@ -46,11 +46,11 @@
 
           {# Atual #}
           {% if not next_item and last_issue %}
-            
+              <a title="{% trans %}número atual{% endtrans %}" href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}" class="btn {{ mmenu.endpoint_selected(view_name='main.issue_grid') }} {% if not 'grid' in request.url_rule.rule %} active {% else %} unselected {% endif %}{% if mmenu.endpoint_selected(view_name='main.journal_detail') %} unselected {% endif %}">
               {% trans %}Número atual{% endtrans %}
             </a>
           {% else %}
-            <a title="{% trans %}número atual{% endtrans %}" href="#" class="btn">
+              <a title="{% trans %}número atual{% endtrans %}" href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}" class="btn">
               {% trans %}Número atual{% endtrans %}
             </a>
           {% endif %}
@@ -140,7 +140,7 @@
 
           {# Atual #}
           {% if last_issue %}
-            <a href="#" class="btn btn-secondary">
+              <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}" class="btn btn-secondary">
               {% trans %}Atual{% endtrans %}
             </a>
           {% endif %}

--- a/opac/webapp/utils/utils.py
+++ b/opac/webapp/utils/utils.py
@@ -790,3 +790,15 @@ def fetch_and_extract_section(collection_acronym, journal_acronym, language):
 
     return extract_section(content, class_name)
 
+
+def get_children_in_order(page):
+    return sorted(page.child_pages or [], key=lambda p: (p.order, p.name.lower()))
+
+
+def build_breadcrumbs(page):
+    crumbs = []
+    current = page
+    while current.parent_page:
+        crumbs.insert(0, current.parent_page)
+        current = current.parent_page
+    return crumbs

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,6 +94,6 @@ zope.interface==5.5.2
 tox==4.3.5
 PyJWT==2.8.0
 tenacity==8.2.3
--e git+https://git@github.com/scieloorg/opac_schema@v2.9.0#egg=Opac_Schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.10.1#egg=Opac_Schema
 -e git+https://git@github.com/scieloorg/packtools@4.12.4#egg=packtools
 -e git+https://github.com/scieloorg/scieloh5m5.git@1.9.5#egg=scieloh5m5


### PR DESCRIPTION
#### O que esse PR faz?
- Melhora representação do idioma qeu não seja EN, PT e ES  no dropmenu menu
- Cria campos no formulário de Pages para referênciar páginas e navegação entre páginas Pais e Filhas


#### Onde a revisão poderia começar?
Pelos commits

#### Como este poderia ser testado manualmente?
- Acessar a área administrativa
- Criar uma página 1
- Criar outra página atribuindo a página 1 como parent_page
- Ir no sobre o scielo e visualizar a lista das páginas

#### Algum cenário de contexto que queira dar?
Essa PR depende de https://github.com/scieloorg/opac_schema/pull/116
https://github.com/scieloorg/opac-airflow/pull/493
e da atualizacao das dependencias: https://github.com/scieloorg/docker-airflow

### Screenshots
<img width="1720" height="275" alt="image" src="https://github.com/user-attachments/assets/8750e030-3a17-4fe0-b877-56335a80e666" />


#### Quais são tickets relevantes?
CLOSE 335 (este número está errado)

### Referências


