### PR TITLE
Corrige registro de nome de autors e author_meta na base de dados

### DIFF
--- a/opac/webapp/factory.py
+++ b/opac/webapp/factory.py
@@ -299,15 +299,13 @@ class AuxiliarArticleFactory:
         self.doc.fpage_sequence = fpage_seq
         self.doc.lpage = lpage
 
-    def add_author(self, surname, given_names, suffix, affiliation, orcid):
+    def add_author(self, name, affiliation, orcid):
         # author meta
         # authors_meta = EmbeddedDocumentListField(AuthorMeta))
         if self.doc.authors_meta is None:
             self.doc.authors_meta = []
         author = models.AuthorMeta()
-        author.surname = surname
-        author.given_names = given_names
-        author.suffix = suffix
+        author.name = name
         author.affiliation = affiliation
         author.orcid = orcid
         self.doc.authors_meta.append(author)
@@ -315,12 +313,7 @@ class AuxiliarArticleFactory:
         # author
         if self.doc.authors is None:
             self.doc.authors = []
-        _author = _format_author_name(
-            surname,
-            given_names,
-            suffix,
-        )
-        self.doc.authors.append(_author)
+        self.doc.authors.append(name)
 
     def add_translated_title(self, language, name):
         # translated_titles = EmbeddedDocumentListField(TranslatedTitle))
@@ -525,9 +518,7 @@ def ArticleFactory(
 
     for item in data.get("authors_meta") or []:
         factory.add_author(
-            surname=item.get("surname"),
-            given_names=item.get("given_names"),
-            suffix=item.get("suffix"),
+            name=item.get("name"),
             affiliation=item.get("affiliation"),
             orcid=item.get("orcid"),
         )


### PR DESCRIPTION
Perfeito, agora entendi o problema real. Vou reescrever o PR:

---

# Pull Request

## Título

Corrige registro de nome de autor na base de dados

## Descrição

Corrige bug onde o campo `name` dos autores não estava sendo registrado na base de dados, pois o `factory.py` esperava campos `surname`, `given_names` e `suffix` que não existem no schema atual.

### Problema

O método `add_author` em `factory.py` tentava extrair `surname`, `given_names` e `suffix` dos dados de entrada, porém:
- O schema `AuthorMeta` define apenas o campo `name` (https://github.com/scieloorg/opac_schema/blob/master/opac_schema/v1/models.py)
- Os dados de entrada fornecem `name` diretamente
- Resultado: o nome do autor não era persistido na base de dados

### Solução

- Atualiza `add_author` para receber e usar `name` diretamente
- Remove referências aos campos inexistentes `surname`, `given_names` e `suffix`
- Remove chamada à função `_format_author_name`

### Arquivos alterados

- **`opac/webapp/factory.py`**

### Checklist

- [ ] Verificar se `_format_author_name` pode ser removida (se não for usada em outro lugar)
- [ ] Testar persistência correta do campo `name` em `authors_meta`
- [ ] Verificar artigos existentes que possam ter sido afetados

