### PR TITLE
ajuste na nomenclatura da tag da imagem docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
 
       - name: Docker Login
         uses: docker/login-action@v3


### PR DESCRIPTION
# Correção do versionamento no workflow de release

## Descrição
Este PR corrige a forma como a versão é extraída da tag Git no workflow de release, removendo a manipulação desnecessária do prefixo "v".

## Mudanças
- **Linha 19**: Alterado de `VERSION=${GITHUB_REF_NAME#v}` para `VERSION=${GITHUB_REF_NAME}`
  - Remove a remoção automática do prefixo "v" da tag
  - Mantém o nome da tag exatamente como foi criada
  - Garante consistência no versionamento

## Motivo
A remoção do prefixo "v" (`${GITHUB_REF_NAME#v}`) estava causando inconsistência entre a tag criada e a versão utilizada no processo de release. Com esta mudança, o workflow preserva o formato original da tag em todas as etapas do processo.

## Impacto
- ✅ Versionamento consistente em todo o pipeline
- ✅ Tags refletidas corretamente nos commits de release
- ✅ Melhor rastreabilidade entre tags Git e versões deployadas

## Teste
Para validar esta mudança, criar uma tag seguindo o padrão estabelecido e verificar se o workflow executa corretamente com a versão esperada.