### PR TITLE
Fix: correção do id do logo da home

### DIFF
--- a/opac/webapp/templates/collection/includes/header.html
+++ b/opac/webapp/templates/collection/includes/header.html
@@ -93,7 +93,7 @@
           <a href="/" alt="{{ coll_macro.get_collection_name() }}" aria-label="{% trans %}Acessar site coleção Brasil{% endtrans %}">
             <span class="visually-hidden">Logo SciELO</span>
             <h2 class="scielo__logo-scielo-caption mt-1">
-              <small id="collection">{{ coll_macro.get_collection_name() }}</small>
+              <small id="collectionNameHome">{{ coll_macro.get_collection_name() }}</small>
             </h2>
           </a>
         </div>


### PR DESCRIPTION
Correção do id do logo da home para que ocorra o ajuste de adequação do nome da coleção se necessário.

#### O que esse PR faz?
Corrige o valor do id do logo da home.

#### Onde a revisão poderia começar?
Carregue a atualização e verifique se o elemento small contido dentro do logo de classe scielo__logo-scielo-caption está com o id="collectionNameHome"

#### Como este poderia ser testado manualmente?
Siga os passos descritos anteriormente.

#### Algum cenário de contexto que queira dar?
-

### Screenshots
-

#### Quais são tickets relevantes?
-

### Referências
Indique as referências utilizadas para a elaboração do pull request.

