### PR TITLE
Atualiza a versão do trivy action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
       # 🔐 Scan único (policy)
       - name: Trivy Image Scan
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: infrascielo/opac_5:${{ env.VERSION }}
           severity: HIGH,CRITICAL


### PR DESCRIPTION
## O que esse PR faz?

Corrige o erro "Unable to resolve action `aquasecurity/trivy-action@0.20.0`" no workflow de release. A versão `0.20.0` não existe — o repositório migrou para o prefixo `v` nas tags. A action é atualizada para `v0.35.0`.

## Onde a revisão poderia começar?

`.github/workflows/release.yml` (linha 36).

## Como este poderia ser testado manualmente?

1. Fazer merge do PR e criar uma tag (ex.: `v5.9.15-test`)
2. Conferir se o workflow de release executa sem o erro "Unable to resolve action"
3. Verificar se o scan do Trivy é executado corretamente

## Algum cenário de contexto que queira dar?

O repositório `aquasecurity/trivy-action` migrou todas as tags para usar o prefixo `v` (ex.: `v0.35.0` em vez de `0.35.0`) após um incidente de supply chain. A tag `0.20.0` nunca existiu nesse formato e causava falha na resolução da action.

## Screenshots

_Quando aplicável, adicione screenshots que remetam à situação gráfica do problema que o pull request resolve._

## Quais são tickets relevantes?

_Indique uma issue ao qual o pull request faz relacionamento._

## Referências

- [aquasecurity/trivy-action - Releases](https://github.com/aquasecurity/trivy-action/releases)
