### PR TITLE
Fix: remoção de atributo aria-expanded do summary. Remoção da lógica …

### DIFF
--- a/opac/webapp/templates/collection/includes/nav.html
+++ b/opac/webapp/templates/collection/includes/nav.html
@@ -4,8 +4,7 @@
 <details class="scielo__accessibleMenu" id="scieloMainMenu">
   <summary
     id="scieloMainMenuSummary"
-    aria-controls="scieloMainMenuNav"
-    aria-expanded="false">
+    aria-controls="scieloMainMenuNav">
     <span class="menu-icon" aria-hidden="true"></span>
     <span>{% trans %}Menu{% endtrans %}</span>
   </summary>
@@ -167,25 +166,15 @@
     const summary = document.getElementById('scieloMainMenuSummary');
     if (!summary) return;
 
-    function syncExpanded() {
-      summary.setAttribute('aria-expanded', details.open ? 'true' : 'false');
-    }
-
-    syncExpanded();
-
-    details.addEventListener('toggle', syncExpanded);
-
     document.addEventListener('click', function (event) {
       if (!details.contains(event.target) && details.open) {
         details.open = false;
-        syncExpanded();
       }
     });
 
     document.addEventListener('keydown', function (event) {
       if (event.key === 'Escape' && details.open) {
         details.open = false;
-        syncExpanded();
         summary.focus();
       }
     });


### PR DESCRIPTION
Fix: remoção de atributo aria-expanded do summary. Remoção da lógica javascript que se referia ao atributo removido.

#### O que esse PR faz?
Remove o atributo aria-expanded do elemento summary. Este é um atributo inválido para este elemento.

#### Onde a revisão poderia começar?
Carregue os arquivos e navegue normalmente pelo sistema. Abra o menu sanduiche, localizado no canto superior esquerdo da tela. Use normalmente e navegue com teclado. Veja se o comportamento ocorre como esperado.
Testar em validadores de acessibilidade. Verificar se o erro referente ao atributo aria desapareceu e também se continua acusando erro de remoção de foco via javascript.

#### Como este poderia ser testado manualmente?
Siga os passos descritos anteriormente

#### Algum cenário de contexto que queira dar?
Importante após a atualização realizar testes de acessibilidade em um artigo. Use o validador amaweb:
https://amaweb.unifesp.br/avaliador/

### Screenshots
-

#### Quais são tickets relevantes?
-

### Referências
-

