### PR TITLE
Configura timeout do fetch HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ ALERT_MSG_ES=Nuevo portal puede contener incorrecciones
 |        OPAC_SSM_PORT  	|         80  	|          80, 8000           	|       21/11/2021           	|        Dominio/FQDN da conexão com SSM.    |
 |        OPAC_SSM_MEDIA_PATH  	|         '/media/assets/'  	|          '/media/assets/', '/media/files/'           	|       21/11/2021           	|        Path da pasta media do assests no SSM.    |
 |        OPAC_SSM_XML_URL_REWRITE  	|         True  	|          True/False            	|       21/11/2021           	|        Troca o scheme + authority da URL armazenada em Article.xml por `OPAC_SSM_SCHEME + '://' + OPAC_SSM_DOMAIN + ':' + OPAC_SSM_PORT`.    |
+|        OPAC_FETCH_DATA_TIMEOUT  	|         10  	|          10, 30, 60            	|       04/05/2026           	|        Timeout em segundos para requisicoes feitas por fetch_data, incluindo SSM/Kernel.    |
 |        OPAC_SERVER_NAME  	|         None  	|          www.scielo.br, www.scielosp.org            	|       21/11/2021           	|        Nome: IP do servidor    |
 |        OPAC_SESSION_COOKIE_DOMAIN  	|         OPAC_SERVER_NAME  	|          www.scielo.br, www.scielosp.org            	|       21/11/2021           	|        O dominio para a cookie da sessão     |
 |        OPAC_SESSION_COOKIE_HTTPONLY  	|         True  	|          True/False            	|       21/11/2021           	|        Seta a flag: httponly da cookie.     |

--- a/opac/tests/test_utils.py
+++ b/opac/tests/test_utils.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock, patch
 
 import webapp
+from flask import current_app
 from webapp import utils as wutils
 
 from . import utils
@@ -10,6 +11,28 @@ from .base import BaseTestCase
 
 
 class UtilsTestCase(BaseTestCase):
+    @patch("requests.get")
+    def test_fetch_data_uses_configured_timeout(self, mocked_requests_get):
+        original_timeout = current_app.config.get("FETCH_DATA_TIMEOUT")
+        current_app.config["FETCH_DATA_TIMEOUT"] = 30
+        mocked_response = Mock()
+        mocked_response.content = b"content"
+        mocked_response.raise_for_status.return_value = None
+        mocked_requests_get.return_value = mocked_response
+
+        try:
+            content = wutils.fetch_data("https://kernel.scielo.br/documents/abc")
+        finally:
+            current_app.config["FETCH_DATA_TIMEOUT"] = original_timeout
+
+        self.assertEqual(b"content", content)
+        mocked_requests_get.assert_called_once_with(
+            "https://kernel.scielo.br/documents/abc",
+            headers=None,
+            timeout=30,
+            verify=True,
+        )
+
     # Issue
     def test_get_prev_issue(self):
         """

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -118,6 +118,9 @@ import ast
         - OPAC_SSM_MEDIA_PATH: Path da pasta media do assests no SSM. Ex. '/media/assets/' -  (default: '/media/assets/')
         - OPAC_SSM_XML_URL_REWRITE: Troca o scheme + authority da URL armazenada em Article.xml por `OPAC_SSM_SCHEME + '://' + OPAC_SSM_DOMAIN + ':' + OPAC_SSM_PORT`. Variável booleana: 'False' (default: 'True')
 
+      - Requisições HTTP:
+        - OPAC_FETCH_DATA_TIMEOUT: timeout em segundos para requisições feitas por fetch_data, incluindo SSM/Kernel. (default: 10)
+
       - Cookie de Sessão: (http://flask.pocoo.org/docs/0.12/config/#builtin-configuration-values)
         - OPAC_SERVER_NAME: Nome:IP do servidor - (default: None)
         - OPAC_SESSION_COOKIE_DOMAIN: o dominio para a cookie da sessão (default: OPAC_SERVER_NAME)
@@ -495,6 +498,7 @@ SSM_PORT = os.environ.get("OPAC_SSM_PORT", "443")
 SSM_MEDIA_PATH = os.environ.get("OPAC_SSM_MEDIA_PATH", "/media/assets/")
 SSM_XML_URL_REWRITE = os.environ.get("OPAC_SSM_XML_URL_REWRITE", "True") == "True"
 SSM_ARTICLE_ASSETS_OR_RENDITIONS_URL_REWRITE = SSM_XML_URL_REWRITE
+FETCH_DATA_TIMEOUT = int(os.environ.get("OPAC_FETCH_DATA_TIMEOUT", 10))
 
 HTML_GENERATOR_VERSION = os.environ.get("HTML_GENERATOR_VERSION", "3.0")
 
@@ -692,5 +696,4 @@ SITE_LICENSE_IMG_MINI_URL = os.environ.get("OPAC_SITE_LICENSE_IMG_MINI_URL") or 
 # Lê a variável e compara com 'True', 'true', '1', etc.
 ANALYTICS_AGENT_DARKVISITORS_ENABLED = os.environ.get('OPAC_ANALYTICS_AGENT_DARKVISITORS_ENABLED', 'False').lower() in ('true', '1', 't', 'yes', 'y')
 ANALYTICS_AGENT_DARKVISITORS_PROJECT_KEY = os.environ.get("OPAC_ANALYTICS_AGENT_DARKVISITORS_PROJECT_KEY")
-
 

--- a/opac/webapp/utils/utils.py
+++ b/opac/webapp/utils/utils.py
@@ -16,7 +16,7 @@ from citeproc import (Citation, CitationItem, CitationStylesBibliography,
                       CitationStylesStyle, formatter)
 from citeproc.source.json import CiteProcJSON
 from citeproc_styles import get_style_filepath
-from flask import current_app, render_template
+from flask import current_app, has_app_context, render_template
 from flask_mail import Message
 from itsdangerous import URLSafeTimedSerializer
 from legendarium.urlegendarium import URLegendarium
@@ -41,6 +41,7 @@ REGEX_EMAIL = re.compile(
     re.IGNORECASE,
 )  # RFC 2822 (simplified)
 logger = logging.getLogger(__name__)
+DEFAULT_FETCH_DATA_TIMEOUT = 10
 
 
 class RetryableError(Exception):
@@ -705,7 +706,15 @@ def render_citation(csl_json, style="apa", formatter=formatter.html, validate=Fa
     wait=wait_exponential(multiplier=1, min=1, max=5),
     stop=stop_after_attempt(5),
 )
-def fetch_data(url, headers=None, json=False, timeout=4, verify=True):
+def _get_fetch_data_timeout(timeout=None):
+    if timeout is not None:
+        return timeout
+    if has_app_context():
+        return current_app.config.get("FETCH_DATA_TIMEOUT", DEFAULT_FETCH_DATA_TIMEOUT)
+    return int(os.environ.get("OPAC_FETCH_DATA_TIMEOUT", DEFAULT_FETCH_DATA_TIMEOUT))
+
+
+def fetch_data(url, headers=None, json=False, timeout=None, verify=True):
     """
     Get the resource with HTTP
     Retry: Wait 2^x * 1 second between each retry starting with 4 seconds,
@@ -714,6 +723,7 @@ def fetch_data(url, headers=None, json=False, timeout=4, verify=True):
         url: URL address
         headers: HTTP headers
         json: True|False
+        timeout: HTTP request timeout in seconds.
         verify: Verify the SSL.
     Returns:
         Return a requests.response object.
@@ -723,6 +733,7 @@ def fetch_data(url, headers=None, json=False, timeout=4, verify=True):
 
     try:
         logger.info("Fetching the URL: %s" % url)
+        timeout = _get_fetch_data_timeout(timeout)
         response = requests.get(url, headers=headers, timeout=timeout, verify=verify)
     except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
         logger.error("Erro fetching the content: %s, retry..., erro: %s" % (url, exc))
@@ -789,4 +800,3 @@ def fetch_and_extract_section(collection_acronym, journal_acronym, language):
     content = fetch_data(url=url)
 
     return extract_section(content, class_name)
-


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona uma configuração para ajustar o timeout das requisições HTTP feitas por `fetch_data`.

Antes o timeout era fixo em `4` segundos. Agora ele pode ser configurado pela variável de ambiente `OPAC_FETCH_DATA_TIMEOUT`, com valor padrão de `10` segundos. Isso ajuda a reduzir erros de timeout em chamadas para recursos externos como `kernel.scielo.br`/SSM.

Também adiciona teste garantindo que o valor configurado é repassado para `requests.get` e documenta a nova variável no `README`.

#### Onde a revisão poderia começar?
A revisão pode começar por:

`opac/webapp/utils/utils.py`

Em seguida:
`opac/webapp/config/default.py`  
`opac/tests/test_utils.py`  
`README.md`

#### Como este poderia ser testado manualmente?
1. Configurar a variável de ambiente com um timeout maior:

```bash
export OPAC_FETCH_DATA_TIMEOUT=30
```

2. Iniciar a aplicação normalmente.

3. Acessar uma página/rota que carregue conteúdo via `fetch_data`, como XML, HTML, PDF ou assets servidos pelo SSM/Kernel.

4. Confirmar nos logs que erros como este deixam de ocorrer para respostas que demoram mais de 4 segundos:

```text
Read timed out. (read timeout=4)
```

Também foi executado teste automatizado focado:

```bash
docker compose -f docker-compose-dev.yml run --rm opac_webapp sh -lc "cd /app && OPAC_CONFIG=config/templates/testing.template flask --app opac.app test -p test_utils.UtilsTestCase.test_fetch_data_uses_configured_timeout"
```

#### Algum cenário de contexto que queira dar?
Foram observados erros de timeout ao buscar documentos no Kernel, por exemplo:

```text
ERROR:webapp.utils.utils:Erro fetching the content: https://kernel.scielo.br/documents/..., retry..., erro: HTTPSConnectionPool(...): Read timed out. (read timeout=4)
```

Como o tempo estava fixo no código, não havia uma forma simples de ajustar esse limite por ambiente.

### Screenshots
Não aplicável. A alteração não possui impacto visual.

#### Quais são tickets relevantes?
Não informado.

### Referências
Não foram utilizadas referências externas. A alteração foi baseada no comportamento atual de `fetch_data` e nas configurações existentes do projeto.