### PR TITLE
Atualiza packtools 4.16.3 (resolve bug de página de artigo cujos abstract não tem elemento title)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -95,5 +95,5 @@ tox==4.3.5
 PyJWT==2.8.0
 tenacity==8.2.3
 -e git+https://git@github.com/scieloorg/opac_schema@v2.9.0#egg=Opac_Schema
--e git+https://git@github.com/scieloorg/packtools@4.16.0#egg=packtools
+-e git+https://git@github.com/scieloorg/packtools@4.16.3#egg=packtools
 -e git+https://github.com/scieloorg/scieloh5m5.git@1.9.5#egg=scieloh5m5


### PR DESCRIPTION
Defeito causado por erro na xsl para "renderizar" resumos que não tem o elemento title. Nesta situação a XSL tentava criar atributos em um elemento inexistente.


https://github.com/scieloorg/packtools/pull/1209