### PR TITLE
Add parâmentro acrônimo do periódico na API counter_dict

### DIFF
--- a/opac/tests/test_restapi.py
+++ b/opac/tests/test_restapi.py
@@ -570,6 +570,60 @@ class RestAPIIssueSyncTestCase(BaseTestCase):
 
 class RestAPICounterDictTestCase(BaseTestCase):
 
+    def test_counter_dict_filter_by_journal_acronym(self):
+        """Test that counter_dict returns only articles for the given journal acronym."""
+        with current_app.app_context():
+            journal_a = makeOneJournal({"_id": "1111-1111", "acronym": "jrn-a"})
+            journal_b = makeOneJournal({"_id": "2222-2222", "acronym": "jrn-b"})
+
+            now = datetime.datetime.now()
+            makeOneArticle({
+                "_id": "art-a1",
+                "aid": "art-a1",
+                "journal": journal_a,
+                "updated": now,
+            })
+            makeOneArticle({
+                "_id": "art-b1",
+                "aid": "art-b1",
+                "journal": journal_b,
+                "updated": now,
+            })
+
+            with self.client as client:
+                response = client.get(
+                    url_for("restapi.router_counter_dicts", journal="jrn-a"),
+                    follow_redirects=True,
+                )
+                self.assertEqual(response.status_code, 200)
+                data = response.get_json()
+                self.assertEqual(data["total"], 1)
+                self.assertIn("art-a1", data["documents"])
+                self.assertNotIn("art-b1", data["documents"])
+
+    def test_counter_dict_filter_by_nonexistent_journal_acronym(self):
+        """Test that counter_dict returns no articles for a non-existent journal acronym."""
+        with current_app.app_context():
+            journal_a = makeOneJournal({"_id": "1111-1111", "acronym": "jrn-a"})
+
+            now = datetime.datetime.now()
+            makeOneArticle({
+                "_id": "art-a1",
+                "aid": "art-a1",
+                "journal": journal_a,
+                "updated": now,
+            })
+
+            with self.client as client:
+                response = client.get(
+                    url_for("restapi.router_counter_dicts", journal="unknown"),
+                    follow_redirects=True,
+                )
+                self.assertEqual(response.status_code, 200)
+                data = response.get_json()
+                self.assertEqual(data["total"], 0)
+                self.assertEqual(data["documents"], {})
+
     def test_counter_dict_filter_by_journal_id(self):
         """Test that counter_dict returns only articles for the given journal_id."""
         with current_app.app_context():

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1483,12 +1483,19 @@ def get_article_by_suppl_material_filename(journal_acron, issue_label, pdf_filen
         return article
 
 
-def get_articles_by_date_range(begin_date, end_date, page=1, per_page=100, journal_id=None):
+def get_articles_by_date_range(
+    begin_date, end_date, page=1, per_page=100, journal_id=None, journal_acronym=None
+):
     """
     Retorna artigos criados ou atualizados durante o período entre start_date e end_date.
     """
     query = Q(updated__gte=begin_date) & Q(updated__lte=end_date)
-    if journal_id:
+    if journal_acronym:
+        journal = get_journal_by_acron(journal_acronym)
+        if not journal:
+            return Pagination(Article.objects(_id__in=[]), page, per_page)
+        query = query & Q(journal=journal)
+    elif journal_id:
         query = query & Q(journal=journal_id)
     articles = Article.objects(query).order_by("pid")
     return Pagination(articles, page, per_page)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1979,6 +1979,7 @@ def router_counter_dicts():
         limit = 100
 
     journal_id = request.args.get("journal_id", type=str)
+    journal_acronym = request.args.get("journal", type=str)
 
     results = {
         "dictionary_date": end_date,
@@ -1989,7 +1990,12 @@ def router_counter_dicts():
     }
 
     articles = controllers.get_articles_by_date_range(
-        begin_date, end_date, page, limit, journal_id=journal_id
+        begin_date,
+        end_date,
+        page,
+        limit,
+        journal_id=journal_id,
+        journal_acronym=journal_acronym,
     )
     for a in articles.items:
         results["documents"].update(get_article_counter_data(a))


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona paramentro "journal" na API counter_dict que busca pelo acronimo do periódico

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
GET /api/v1/counter_dict?end_date=2021-08-25&begin_date=2021-08-24&limit=100&journal=rsp


#### Quais são tickets relevantes?
https://github.com/scieloorg/opac_5/issues/470


