### PR TITLE
Adiciona "status" do artigo no resultado da API counter_dict

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1863,6 +1863,7 @@ def get_article_counter_data(article):
             "pid_v3": article.scielo_pids.get("v3", ""),
             "publication_date": article.publication_date,
             "default_language": article.original_language,
+            "status": article.is_public,
             "create": article.created,
             "update": article.updated,
         }


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona "status" do artigo no resultado da API counter_dict

#### Como este poderia ser testado manualmente?
Acessar APi de counter_dict:
GET /api/v1/counter_dict


Fix #472
