### PR TITLE
Avoid mapReduce for issue TOC sections

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -908,9 +908,7 @@ def issue_toc(url_seg, url_seg_issue):
     articles = controllers.get_articles_by_iid(issue.iid, is_public=True)
 
     # obtém todas as seções
-    sections = sorted(
-        {s.upper() for s in articles.item_frequencies("section", normalize=True).keys()}
-    )
+    sections = sorted({s.upper() for s in articles.distinct("section") if s})
 
     # obtém os documentos da seção selecionada
     try:


### PR DESCRIPTION
#### O que esse PR faz?
Substitui o uso de `item_frequencies("section")` na página de sumário do fascículo por `distinct("section")`.

Essa alteração evita que o MongoEngine acione `mapReduce` para listar as seções dos artigos, reduzindo logs e operações temporárias no MongoDB como criação de coleções `tmp.mr.article_*`, `drop` de `inline` e `renameCollection`.

#### Onde a revisão poderia começar?
`opac/webapp/main/views.py`

A revisão pode começar pela função `issue_toc`, no trecho que monta a lista de seções do fascículo.

#### Como este poderia ser testado manualmente?
1. Subir a aplicação com uma base MongoDB contendo fascículos e artigos publicados.
2. Acessar a página de sumário de um fascículo.
3. Verificar se a página continua exibindo corretamente as seções dos artigos.
4. Confirmar que o filtro por seção continua funcionando quando habilitado.
5. Observar os logs do MongoDB ao acessar a página e verificar que não aparecem novas operações relacionadas a `tmp.mr.article_*` ou `mapReduce`.

#### Algum cenário de contexto que queira dar?
Os logs do MongoDB estavam mostrando operações repetidas de `mapReduce`, com criação de coleções temporárias `tmp.mr.article_*`, remoção da coleção `inline` e renomeação da coleção temporária.

A chamada `item_frequencies` era usada apenas para obter os nomes distintos das seções. Como a contagem/frequência não era utilizada, `distinct("section")` atende ao mesmo objetivo de forma mais simples e sem acionar `mapReduce`.

### Screenshots
Não aplicável. A alteração é interna e não muda a interface visual esperada.

#### Quais são tickets relevantes?
Não informado.

### Referências
- Logs do MongoDB indicando operações `tmp.mr.article_*`, `drop opac_br.inline` e `renameCollection`.
- Código alterado: `opac/webapp/main/views.py`.

