### PR TITLE
fix: atualiza packtools para 4.16.5 para corrigir exibição de disponibilidade de dados em fn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -95,5 +95,5 @@ tox==4.3.5
 PyJWT==2.8.0
 tenacity==8.2.3
 git+https://github.com/scieloorg/opac_schema@v2.9.0#egg=Opac_Schema
-git+https://github.com/scieloorg/packtools@4.16.3#egg=packtools
+git+https://github.com/scieloorg/packtools@4.16.5#egg=packtools
 git+https://github.com/scieloorg/scieloh5m5@1.9.5#egg=scieloh5m5


### PR DESCRIPTION

#### **Descrição do problema**

Para os artigos enviados para o site da SciELO Br que tiveram a marcação da Disponibilidade de dados em `<fn>`, a informação aparece duplicada como um link que não leva para lugar algum ao final da página.

A marcação de `data-availability` pode ser realizada em `<fn>` ou `<sec>`, porém, apenas para os artigos marcados em `<fn>` ocorria esse comportamento inesperado de link quebrado.

#### **Solução aplicada**

Atualização da dependência do `packtools` para a versão `4.16.5`. Esta versão corrige o processamento e a renderização da seção de disponibilidade de dados quando estruturada dentro de notas de rodapé (`<fn>`), garantindo que o texto seja exibido corretamente.

#### **Como testar**

1. Acesse um artigo XML que contenha a marcação de disponibilidade de dados em `<fn>`, como no exemplo abaixo:
```xml
<fn fn-type="data-availability" specific-use="data-not-available" id="fn5a">
    <label>Data Availability</label>
    <p>RAC encourages data sharing but...</p>
</fn>

```
2. Verifique a página do artigo e certifique-se de que a seção ao final da página renderiza o texto normalmente.

**Nota**: A seção "Disponibilidade de Dados" é conscientemente duplicada porque é um destaque desta informação. Então ela ocorrerá no decorrer do texto onde o periódico a colocou e, pelo layout do site, ela ficará também no final da página junto com as datas de publicação e com o histórico.

Closes #479