### PR TITLE
fix(admin): corrige edição da coleção com WTForms 3.2, após atualização de dependência ``flask-mongoengine``

### DIFF
--- a/opac/tests/test_admin_views.py
+++ b/opac/tests/test_admin_views.py
@@ -4263,6 +4263,40 @@ class CollectionAdminViewTests(BaseTestCase):
             can_edit = self.get_context_variable("admin_view").can_edit
             self.assertTrue(can_edit)
 
+    def test_admin_collection_edit_view_renders_with_sponsors(self):
+        """
+        Com:
+            - usuário administrador cadastrado (com email confirmado)
+            - uma coleção com financiadores associados
+        Quando:
+            - acessamos a pagina de edição da coleção
+        Verificamos:
+            - que o formulário é renderizado sem erro
+        """
+        collection = makeOneCollection()
+        sponsor = makeOneSponsor({"order": 1, "name": "Financiador QA"})
+        collection.sponsors = [sponsor]
+        collection.save()
+
+        admin_user = {
+            "email": "admin@opac.org",
+            "password": "foobarbaz",
+        }
+        create_user(admin_user["email"], admin_user["password"], True)
+        login_url = url_for("admin.login_view")
+        collection_edit_url = url_for("collection.edit_view")
+
+        with self.client as client:
+            login_response = client.post(
+                login_url, data=admin_user, follow_redirects=True
+            )
+            self.assertStatus(login_response, 200)
+
+            edit_response = client.get(collection_edit_url)
+            self.assertStatus(edit_response, 200)
+            self.assertTemplateUsed("admin/model/modals/edit.html")
+            self.assertIn(sponsor.name, edit_response.data.decode("utf-8"))
+
     def test_admin_collection_check_can_delete_is_false(self):
         """
         Com:

--- a/opac/webapp/__init__.py
+++ b/opac/webapp/__init__.py
@@ -112,6 +112,10 @@ def configure_apm_agent(app):
 
 
 def create_app():
+    from .wtforms_compat import apply_wtforms_compat
+
+    apply_wtforms_compat()
+
     app = Flask(
         __name__,
         static_url_path="/static",

--- a/opac/webapp/wtforms_compat.py
+++ b/opac/webapp/wtforms_compat.py
@@ -1,0 +1,59 @@
+# coding: utf-8
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_PATCHED = False
+
+
+def _wtforms_major_minor():
+    import wtforms
+
+    return tuple(int(part) for part in wtforms.__version__.split(".")[:2])
+
+
+def iter_choice(val, label, selected):
+    """Return a choice tuple compatible with the installed WTForms version."""
+    if _wtforms_major_minor() >= (3, 2):
+        return val, label, selected, {}
+    return val, label, selected
+
+
+def _patch_iter_choices_method(cls):
+    original = cls.iter_choices
+    if getattr(original, "_wtforms_compat_patched", False):
+        return
+
+    def patched(self):
+        for choice in original(self):
+            if isinstance(choice, tuple) and len(choice) == 3:
+                yield iter_choice(*choice)
+            else:
+                yield choice
+
+    patched._wtforms_compat_patched = True
+    cls.iter_choices = patched
+
+
+def apply_wtforms_compat():
+    """Patch third-party fields that still yield 3-tuples for WTForms 3.2+."""
+    global _PATCHED
+
+    if _PATCHED or _wtforms_major_minor() < (3, 2):
+        return
+
+    from flask_admin.contrib.sqla import fields as sqla_fields
+    from flask_admin.form import fields as admin_fields
+    from flask_mongoengine.wtf import fields as me_fields
+
+    for cls in (
+        admin_fields.Select2Field,
+        sqla_fields.QuerySelectField,
+        sqla_fields.QuerySelectMultipleField,
+        me_fields.QuerySetSelectField,
+    ):
+        _patch_iter_choices_method(cls)
+
+    _PATCHED = True
+    logger.debug("Applied WTForms 3.2 iter_choices compatibility patches.")


### PR DESCRIPTION
## Descrição 

- Corrige erro 500 ao abrir `/admin/collection/edit/` após upgrade do WTForms para 3.2.2
- Adiciona patch de compatibilidade para campos `Select` do Flask-Admin e flask-mongoengine que ainda retornam tuplas de 3 elementos em `iter_choices()`
- Inclui teste de regressão que renderiza o formulário de edição da coleção com financiadores associados

## Problema

No ambiente de QA, ao acessar a edição da coleção no admin, a aplicação falhava com:

```
ValueError: not enough values to unpack (expected 4, got 3)
```

O erro ocorria na renderização do campo `sponsors` (`ModelSelectMultipleField` com `Select2Widget`), quando existiam financiadores cadastrados no MongoDB.

### Causa raiz

O upgrade de `WTForms 3.0.1 → 3.2.2` alterou o widget `Select` para esperar tuplas de 4 elementos `(value, label, selected, render_kw)` em `iter_choices()`. Porém, `Flask-Admin 1.6.0` e `flask-mongoengine` ainda retornam tuplas de 3 elementos.

O bug só aparecia em QA (e não em desenvolvimento) porque o MongoDB local não tinha financiadores — com queryset vazio, o select renderiza sem opções e o erro não é disparado.

## Solução

Novo módulo `opac/webapp/wtforms_compat.py` que, no startup da aplicação (`create_app()`), aplica um patch em `iter_choices()` das classes afetadas quando WTForms ≥ 3.2:

- `Select2Field` (Flask-Admin)
- `QuerySelectField` / `QuerySelectMultipleField` (Flask-Admin SQLAlchemy)
- `QuerySetSelectField` (flask-mongoengine)

O patch adiciona o quarto elemento (`{}`) às tuplas de 3 elementos, mantendo compatibilidade com versões anteriores do WTForms.

## Arquivos alterados

| Arquivo | Alteração |
|---|---|
| `opac/webapp/wtforms_compat.py` | Novo módulo de compatibilidade |
| `opac/webapp/__init__.py` | Chama `apply_wtforms_compat()` em `create_app()` |
| `opac/tests/test_admin_views.py` | Teste `test_admin_collection_edit_view_renders_with_sponsors` |

## Test plan

- [ ] `make test` (ou `flask --app opac.app test -p test_admin_collection_edit_view_renders_with_sponsors`)
- [ ] Cadastrar um financiador em `/admin/sponsor/`
- [ ] Associar o financiador à coleção
- [ ] Abrir `/admin/collection/edit/` e confirmar que o formulário renderiza sem erro 500
- [ ] Verificar que outros formulários admin com `Select2Field` (ex.: Páginas, Notícias) continuam funcionando