### PR TITLE
Update SQLAlchemy 2.0 

### DIFF
--- a/opac/tests/test_admin_custom_filters.py
+++ b/opac/tests/test_admin_custom_filters.py
@@ -94,8 +94,13 @@ class CustomFiltersTestCase(BaseTestCase):
 
         result = filter_converter.convert("ReferenceField", Issue.journal, "journal")
         expected = [f(Issue.journal, "journal") for f in filtes_reference_field]
-
-        self.assertListEqual([vars(i) for i in expected], [vars(i) for i in result])
+        # Flask-Admin 2.2 normaliza `column` para string internamente.
+        self.assertListEqual([i.name for i in expected], [i.name for i in result])
+        self.assertListEqual([i.options for i in expected], [i.options for i in result])
+        self.assertListEqual(
+            [i.__class__.__name__ for i in expected],
+            [i.__class__.__name__ for i in result],
+        )
 
     def test_filters_list_field(self):
         filter_converter = CustomFilterConverter()
@@ -103,8 +108,12 @@ class CustomFiltersTestCase(BaseTestCase):
 
         result = filter_converter.convert("ListField", Journal.index_at, "index_at")
         expected = [f(Journal.index_at, "index_at") for f in filtes_list_field]
-
-        self.assertListEqual([vars(i) for i in expected], [vars(i) for i in result])
+        self.assertListEqual([i.name for i in expected], [i.name for i in result])
+        self.assertListEqual([i.options for i in expected], [i.options for i in result])
+        self.assertListEqual(
+            [i.__class__.__name__ for i in expected],
+            [i.__class__.__name__ for i in result],
+        )
 
     def test_custom_filter_not_equal(self):
         journal = makeOneJournal({"title": "title-%s" % str(uuid4().hex)})

--- a/opac/webapp/__init__.py
+++ b/opac/webapp/__init__.py
@@ -239,10 +239,10 @@ def create_app():
     )
     admin.add_view(views.NewsAdminView(News, name=lazy_gettext("Notícias")))
     admin.add_view(
-        views.FileAdminView(File, dbsql.session, category=lazy_gettext("Ativos"))
+        views.FileAdminView(File, dbsql, category=lazy_gettext("Ativos"))
     )
     admin.add_view(
-        views.ImageAdminView(Image, dbsql.session, category=lazy_gettext("Ativos"))
+        views.ImageAdminView(Image, dbsql, category=lazy_gettext("Ativos"))
     )
     admin.add_view(views.PagesAdminView(Pages, name=lazy_gettext("Páginas")))
     admin.add_view(
@@ -255,7 +255,7 @@ def create_app():
     admin.add_view(
         views.UserAdminView(
             User,
-            dbsql.session,
+            dbsql,
             category=lazy_gettext("Gestão"),
             name=lazy_gettext("Usuário"),
         )

--- a/opac/webapp/admin/custom_filters.py
+++ b/opac/webapp/admin/custom_filters.py
@@ -135,6 +135,15 @@ class CustomFilterConverter(FilterConverter):
         CustomFilterInList,
         CustomFilterNotInList,
     )
+    string_filters = (
+        CustomFilterLike,
+        CustomFilterNotLike,
+        CustomFilterEqual,
+        CustomFilterNotEqual,
+        CustomFilterEmpty,
+        CustomFilterInList,
+        CustomFilterNotInList,
+    )
     embedded_filters = (
         CustomFilterLike,
         CustomFilterNotLike,
@@ -149,6 +158,12 @@ class CustomFilterConverter(FilterConverter):
     @filters.convert("ReferenceField")
     def conv_reference(self, column, name):
         return [f(column, name) for f in self.reference_filters]
+
+    @filters.convert("StringField")
+    @filters.convert("URLField")
+    @filters.convert("EmailField")
+    def conv_string(self, column, name):
+        return [f(column, name) for f in self.string_filters]
 
     @filters.convert("EmbeddedDocumentField")
     def conv_embedded(self, column, name):

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1585,7 +1585,7 @@ def get_user_by_id(id):
     if not isinstance(id, int):
         raise ValueError(__("Parâmetro email deve ser uma inteiro"))
 
-    return dbsql.session.query(User).get(id)
+    return dbsql.session.get(User, id)
 
 
 def set_user_email_confirmed(user):

--- a/opac/webapp/models.py
+++ b/opac/webapp/models.py
@@ -90,7 +90,7 @@ def load_user(user_id):
     Retora usuário pelo id.
     Necessário para o login manager.
     """
-    return User.query.get(int(user_id))
+    return db.session.get(User, int(user_id))
 
 
 class File(db.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-alembic==1.9.2
+alembic==1.14.1
 arrow==1.4.0
 async-timeout==4.0.2
 Babel==2.18.0
@@ -30,7 +30,7 @@ Flask-HTMLmin==2.2.1
 Flask-Login==0.6.3
 Flask-Mail==0.10.0
 flask-mongoengine==1.0.0
-Flask-SQLAlchemy==3.0.2
+Flask-SQLAlchemy==3.1.1
 Flask-WTF==1.3.0
 gevent==24.11.1
 greenlet==3.1.1
@@ -71,8 +71,8 @@ rq-scheduler-dashboard==0.0.2
 sgmllib3k==1.0.0
 six==1.17.0
 soupsieve==2.8.4
-SQLAlchemy==1.4.46
-SQLAlchemy-Utils==0.39.0
+SQLAlchemy==2.0.36
+SQLAlchemy-Utils==0.41.2
 text-unidecode==1.3
 tox==4.56.2
 tweepy==4.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ feedparser==6.0.12
 feedwerk==1.2.0
 filelock==3.29.6
 Flask==3.1.2
-Flask-Admin==2.0.2
+Flask-Admin==2.2.0
 Flask-Babel==4.0.0
 Flask-Caching==2.4.0
 Flask-HTMLmin==2.2.1


### PR DESCRIPTION
#### O que esse PR faz?

- Migra o stack SQLAlchemy para 2.0 e alinhamentos relacionados:
  - `SQLAlchemy` `1.4.46` → `2.0.36`
  - `Flask-SQLAlchemy` `3.0.2` → `3.1.1`
  - `SQLAlchemy-Utils` `0.39.0` → `0.41.2`
  - `alembic` `1.9.2` → `1.14.1`
- Substitui `Query.get()` por `Session.get()` em:
  - `opac/webapp/models.py` (`load_user`)
  - `opac/webapp/controllers.py` (`get_user_by_id`)
- Passa `dbsql` (em vez de `dbsql.session`) para as `ModelView` SQL do Flask-Admin (`User`, `File`, `Image`).


Arquivos principais:

- `requirements.txt`
- `Makefile`
- `opac/webapp/models.py`
- `opac/webapp/controllers.py`
- `opac/webapp/__init__.py`


#### Onde a revisão poderia começar?

1. `requirements.txt` (bump do stack)
2. `opac/webapp/models.py` e `opac/webapp/controllers.py` (`session.get`)
3. `opac/webapp/__init__.py` (`ModelView(..., dbsql)`)

#### Como este poderia ser testado manualmente?

1. Atualizar dependências:
   ```bash
   source venv/bin/activate
   pip install -r requirements.txt
   ```
2. Rodar a suíte:
   ```bash
   make test
   ```
3. (Opcional) Validar warnings de API legada:
   ```bash
   make test_sqlalchemy_warn
   ```
4. Smoke no admin SQL:
   - login de usuário
   - listagem/CRUD de File e Image
   - confirmação / reset de senha (fluxo que usa `load_user` / `get_user_by_id`)

#### Algum cenário de contexto que queira dar?

SQLAlchemy no OPAC cobre só o domínio relacional de admin (`User`, `File`, `Image`). O catálogo (journal/issue/article) permanece no MongoDB.

A preparação com `SQLALCHEMY_WARN_20=1` apontou principalmente `Query.get()` e o aviso do Flask-Admin ao receber `session` em vez do objeto `db`. Este PR resolve esses pontos e sobe o stack para SQLAlchemy 2.0.

`session.query(...)` / `Model.query.filter(...)` ainda existem em alguns pontos e continuam funcionando no 2.0; a migração completa para `select()` pode ser um follow-up.

### Screenshots

N/A (upgrade de dependências / APIs de acesso a dados).

#### Quais são tickets relevantes?

N/A

### Referências

- [SQLAlchemy 2.0 Migration](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html)
- [SQLALCHEMY_WARN_20](https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#migration-to-2-0-step-one-turn-on-removedin20warnings)
- [Flask-SQLAlchemy 3.1](https://flask-sqlalchemy.palletsprojects.com/)
