### PR TITLE
Upgrade to flask MongoEngine 3

### DIFF
--- a/opac/tests/base.py
+++ b/opac/tests/base.py
@@ -28,7 +28,8 @@ class MongoInstance(object):
 
     def __init__(self):
         self._tmpdir = tempfile.mkdtemp()
-        self.mongo_settings = current_app.config["MONGODB_SETTINGS"]
+        settings = current_app.config["MONGODB_SETTINGS"]
+        self.mongo_settings = settings[0] if isinstance(settings, list) else settings
 
         # XXX: wait for the instance to be ready
         #      Mongo is ready in a glance, we just wait to be able to open a
@@ -75,5 +76,9 @@ class BaseTestCase(TestCase):
     def tearDown(self):
         dbsql.session.remove()
         dbsql.drop_all()
-        mongo_db_name = current_app.config["MONGODB_SETTINGS"]["db"]
+        mongo_settings = current_app.config["MONGODB_SETTINGS"]
+        if isinstance(mongo_settings, list):
+            mongo_db_name = mongo_settings[0]["db"]
+        else:
+            mongo_db_name = mongo_settings["db"]
         self.conn.drop_database(mongo_db_name)

--- a/opac/tests/test_admin_custom_filters.py
+++ b/opac/tests/test_admin_custom_filters.py
@@ -94,8 +94,13 @@ class CustomFiltersTestCase(BaseTestCase):
 
         result = filter_converter.convert("ReferenceField", Issue.journal, "journal")
         expected = [f(Issue.journal, "journal") for f in filtes_reference_field]
-
-        self.assertListEqual([vars(i) for i in expected], [vars(i) for i in result])
+        # Flask-Admin 2.2 normaliza `column` para string internamente.
+        self.assertListEqual([i.name for i in expected], [i.name for i in result])
+        self.assertListEqual([i.options for i in expected], [i.options for i in result])
+        self.assertListEqual(
+            [i.__class__.__name__ for i in expected],
+            [i.__class__.__name__ for i in result],
+        )
 
     def test_filters_list_field(self):
         filter_converter = CustomFilterConverter()
@@ -103,8 +108,12 @@ class CustomFiltersTestCase(BaseTestCase):
 
         result = filter_converter.convert("ListField", Journal.index_at, "index_at")
         expected = [f(Journal.index_at, "index_at") for f in filtes_list_field]
-
-        self.assertListEqual([vars(i) for i in expected], [vars(i) for i in result])
+        self.assertListEqual([i.name for i in expected], [i.name for i in result])
+        self.assertListEqual([i.options for i in expected], [i.options for i in result])
+        self.assertListEqual(
+            [i.__class__.__name__ for i in expected],
+            [i.__class__.__name__ for i in result],
+        )
 
     def test_custom_filter_not_equal(self):
         journal = makeOneJournal({"title": "title-%s" % str(uuid4().hex)})

--- a/opac/webapp/__init__.py
+++ b/opac/webapp/__init__.py
@@ -239,10 +239,10 @@ def create_app():
     )
     admin.add_view(views.NewsAdminView(News, name=lazy_gettext("Notícias")))
     admin.add_view(
-        views.FileAdminView(File, dbsql.session, category=lazy_gettext("Ativos"))
+        views.FileAdminView(File, dbsql, category=lazy_gettext("Ativos"))
     )
     admin.add_view(
-        views.ImageAdminView(Image, dbsql.session, category=lazy_gettext("Ativos"))
+        views.ImageAdminView(Image, dbsql, category=lazy_gettext("Ativos"))
     )
     admin.add_view(views.PagesAdminView(Pages, name=lazy_gettext("Páginas")))
     admin.add_view(
@@ -255,7 +255,7 @@ def create_app():
     admin.add_view(
         views.UserAdminView(
             User,
-            dbsql.session,
+            dbsql,
             category=lazy_gettext("Gestão"),
             name=lazy_gettext("Usuário"),
         )

--- a/opac/webapp/admin/custom_filters.py
+++ b/opac/webapp/admin/custom_filters.py
@@ -135,6 +135,15 @@ class CustomFilterConverter(FilterConverter):
         CustomFilterInList,
         CustomFilterNotInList,
     )
+    string_filters = (
+        CustomFilterLike,
+        CustomFilterNotLike,
+        CustomFilterEqual,
+        CustomFilterNotEqual,
+        CustomFilterEmpty,
+        CustomFilterInList,
+        CustomFilterNotInList,
+    )
     embedded_filters = (
         CustomFilterLike,
         CustomFilterNotLike,
@@ -149,6 +158,12 @@ class CustomFilterConverter(FilterConverter):
     @filters.convert("ReferenceField")
     def conv_reference(self, column, name):
         return [f(column, name) for f in self.reference_filters]
+
+    @filters.convert("StringField")
+    @filters.convert("URLField")
+    @filters.convert("EmailField")
+    def conv_string(self, column, name):
+        return [f(column, name) for f in self.string_filters]
 
     @filters.convert("EmbeddedDocumentField")
     def conv_embedded(self, column, name):

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -12,7 +12,7 @@ import ast
       - http://flask.pocoo.org/docs/0.10/config/#builtin-configuration-values
       - https://pythonhosted.org/flask-mail/#configuring-flask-mail
       - http://flask-sqlalchemy.pocoo.org/2.1/config/
-      - https://flask-mongoengine.readthedocs.org/en/latest/#configuration
+      - https://flask-mongoengine-3.readthedocs.io/en/latest/flask_config.html
 
   Para ajustar configurações, pode definir as variáveis de ambiente (ver abaixo) no seu host,
   ou copie o template que melhor se ajuste a seu ambiente, e apontando o caminho absoluto
@@ -279,15 +279,18 @@ MONGODB_PORT = os.environ.get("OPAC_MONGODB_PORT", 27017)
 MONGODB_USER = os.environ.get("OPAC_MONGODB_USER", None)
 MONGODB_PASS = os.environ.get("OPAC_MONGODB_PASS", None)
 
-MONGODB_SETTINGS = {
-    "db": MONGODB_NAME,
-    "host": MONGODB_HOST,
-    "port": int(MONGODB_PORT),
-}
+MONGODB_SETTINGS = [
+    {
+        "db": MONGODB_NAME,
+        "host": MONGODB_HOST,
+        "port": int(MONGODB_PORT),
+        "alias": "default",
+    }
+]
 
 if MONGODB_USER and MONGODB_PASS:
-    MONGODB_SETTINGS["username"] = MONGODB_USER
-    MONGODB_SETTINGS["password"] = MONGODB_PASS
+    MONGODB_SETTINGS[0]["username"] = MONGODB_USER
+    MONGODB_SETTINGS[0]["password"] = MONGODB_PASS
 
 
 # Configurações do banco de dados SQL

--- a/opac/webapp/config/templates/development.template
+++ b/opac/webapp/config/templates/development.template
@@ -75,15 +75,18 @@ MONGODB_PORT = 27017
 # MONGODB_USER = os.environ.get('OPAC_MONGODB_USER', None)
 # MONGODB_PASS = os.environ.get('OPAC_MONGODB_PASS', None)
 
-MONGODB_SETTINGS = {
-    'db': MONGODB_NAME,
-    'host': MONGODB_HOST,
-    'port': int(MONGODB_PORT),
-}
+MONGODB_SETTINGS = [
+    {
+        'db': MONGODB_NAME,
+        'host': MONGODB_HOST,
+        'port': int(MONGODB_PORT),
+        'alias': 'default',
+    }
+]
 
 # if MONGODB_USER and MONGODB_PASS:
-#     MONGODB_SETTINGS['username'] = MONGODB_USER
-#     MONGODB_SETTINGS['password'] = MONGODB_PASS
+#     MONGODB_SETTINGS[0]['username'] = MONGODB_USER
+#     MONGODB_SETTINGS[0]['password'] = MONGODB_PASS
 
 
 # Configurações do banco de dados SQL

--- a/opac/webapp/config/templates/testing.template
+++ b/opac/webapp/config/templates/testing.template
@@ -94,15 +94,18 @@ MONGODB_PORT = os.environ.get('OPAC_MONGODB_PORT', 27017)
 MONGODB_USER = os.environ.get('OPAC_MONGODB_USER', None)
 MONGODB_PASS = os.environ.get('OPAC_MONGODB_PASS', None)
 
-MONGODB_SETTINGS = {
-    'db': MONGODB_NAME,
-    'host': MONGODB_HOST,
-    'port': int(MONGODB_PORT),
-}
+MONGODB_SETTINGS = [
+    {
+        'db': MONGODB_NAME,
+        'host': MONGODB_HOST,
+        'port': int(MONGODB_PORT),
+        'alias': 'default',
+    }
+]
 
 # if MONGODB_USER and MONGODB_PASS:
-#     MONGODB_SETTINGS['username'] = MONGODB_USER
-#     MONGODB_SETTINGS['password'] = MONGODB_PASS
+#     MONGODB_SETTINGS[0]['username'] = MONGODB_USER
+#     MONGODB_SETTINGS[0]['password'] = MONGODB_PASS
 
 
 # Configurações do banco de dados SQL

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1585,7 +1585,7 @@ def get_user_by_id(id):
     if not isinstance(id, int):
         raise ValueError(__("Parâmetro email deve ser uma inteiro"))
 
-    return dbsql.session.query(User).get(id)
+    return dbsql.session.get(User, id)
 
 
 def set_user_email_confirmed(user):

--- a/opac/webapp/flask_compat.py
+++ b/opac/webapp/flask_compat.py
@@ -14,40 +14,9 @@ def apply_flask_23_compat():
     if _PATCHED:
         return
 
-    _patch_json_encoder()
-    _patch_flask_mongoengine_json()
     _patch_before_app_first_request()
     _PATCHED = True
     logger.debug("Applied Flask 2.3 compatibility patches.")
-
-
-def _patch_json_encoder():
-    """Restore flask.json.JSONEncoder for flask-mongoengine."""
-    import json
-
-    import flask.json as flask_json
-
-    if hasattr(flask_json, "JSONEncoder"):
-        return
-
-    class JSONEncoder(json.JSONEncoder):
-        pass
-
-    flask_json.JSONEncoder = JSONEncoder
-
-
-def _patch_flask_mongoengine_json():
-    """Fix flask-mongoengine JSONEncoder setup on Flask 2.3+."""
-    import json
-
-    import flask_mongoengine
-    import flask_mongoengine.json as me_json
-
-    def override_json_encoder(app):
-        app.json_encoder = me_json._make_encoder(json.JSONEncoder)
-
-    me_json.override_json_encoder = override_json_encoder
-    flask_mongoengine.override_json_encoder = override_json_encoder
 
 
 def _patch_before_app_first_request():

--- a/opac/webapp/models.py
+++ b/opac/webapp/models.py
@@ -90,7 +90,7 @@ def load_user(user_id):
     Retora usuário pelo id.
     Necessário para o login manager.
     """
-    return User.query.get(int(user_id))
+    return db.session.get(User, int(user_id))
 
 
 class File(db.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ Flask-Caching==2.4.0
 Flask-HTMLmin==2.2.1
 Flask-Login==0.6.3
 Flask-Mail==0.10.0
-flask-mongoengine==1.0.0
+flask-mongoengine-3[wtf]==1.1.0
 Flask-SQLAlchemy==3.1.1
 Flask-WTF==1.3.0
 gevent==24.11.1
@@ -43,7 +43,7 @@ legendarium==2.0.6
 lxml==5.3.0
 Mako==1.3.12
 MarkupSafe==3.0.2
-mongoengine==0.25.0
+mongoengine==0.29.3
 natsort==8.4.0
 oauthlib==3.3.1
 packaging==26.2
@@ -53,7 +53,7 @@ picles.plumber==0.11
 Pillow==9.4.0
 platformdirs==4.10.0
 pluggy==1.6.0
-pymongo==4.3.3
+pymongo==4.10.1
 pyproject_api==1.10.1
 PySocks==1.7.1
 python-dateutil==2.9.0.post0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-alembic==1.9.2
+alembic==1.14.1
 arrow==1.4.0
 async-timeout==4.0.2
 Babel==2.18.0
@@ -30,7 +30,7 @@ Flask-HTMLmin==2.2.1
 Flask-Login==0.6.3
 Flask-Mail==0.10.0
 flask-mongoengine==1.0.0
-Flask-SQLAlchemy==3.0.2
+Flask-SQLAlchemy==3.1.1
 Flask-WTF==1.3.0
 gevent==24.11.1
 greenlet==3.1.1
@@ -71,8 +71,8 @@ rq-scheduler-dashboard==0.0.2
 sgmllib3k==1.0.0
 six==1.17.0
 soupsieve==2.8.4
-SQLAlchemy==1.4.46
-SQLAlchemy-Utils==0.39.0
+SQLAlchemy==2.0.36
+SQLAlchemy-Utils==0.41.2
 text-unidecode==1.3
 tox==4.56.2
 tweepy==4.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ feedparser==6.0.12
 feedwerk==1.2.0
 filelock==3.29.6
 Flask==3.1.2
-Flask-Admin==2.0.2
+Flask-Admin==2.2.0
 Flask-Babel==4.0.0
 Flask-Caching==2.4.0
 Flask-HTMLmin==2.2.1


### PR DESCRIPTION
#### O que esse PR faz?

- Substitui `flask-mongoengine==1.0.0` (abandonado) por `flask-mongoengine-3[wtf]==1.1.0`.
- Atualiza `mongoengine` `0.25.0` → `0.29.3` e `pymongo` `4.3.3` → `4.10.1`.
- Migra `MONGODB_SETTINGS` do formato dict (deprecated) para lista de dicts (formato recomendado).
- Remove patches de `JSONEncoder` / `override_json_encoder` em `flask_compat.py` (desnecessários com o fork no Flask 3.1). Mantém o shim de `rq-dashboard`.

Arquivos:

- `requirements.txt`
- `opac/webapp/config/default.py`
- `opac/webapp/config/templates/testing.template`
- `opac/webapp/config/templates/development.template`
- `opac/webapp/flask_compat.py`
- `opac/tests/base.py`

#### Onde a revisão poderia começar?

1. `requirements.txt`
2. `opac/webapp/config/default.py` (`MONGODB_SETTINGS` como lista)
3. `opac/webapp/flask_compat.py`
4. `opac/tests/base.py`

#### Como este poderia ser testado manualmente?

1. Atualizar dependências:
   ```bash
   source venv/bin/activate
   pip install -r requirements.txt
   ```
2. Rodar a suíte:
   ```bash
   make test
   ```
3. Smoke:
   - home, lista de periódicos, periódico, TOC, artigo HTML/PDF
   - admin: listagens/filtros de journal/issue/article

#### Algum cenário de contexto que queira dar?

O pacote oficial `flask-mongoengine` não recebe releases e quebrava com Flask 3 (por isso os shims de JSON). O fork `flask-mongoengine-3` mantém o mesmo import (`flask_mongoengine`) e é compatível com Flask moderno e WTForms 3.

`MONGODB_SETTINGS` como dict único está deprecated no fork; a lista com `alias: "default"` é o formato recomendado. O `wtforms_compat.py` para `QuerySetSelectField` permanece (WTForms 3.2).

Validado contra MongoDB 4.x (PyMongo 4.10.1 declara suporte a 4.2). Upgrade do servidor MongoDB permanece fora deste PR.

### Screenshots

N/A (upgrade de dependências / config).

#### Quais são tickets relevantes?

N/A

### Referências

- [flask-mongoengine-3](https://pypi.org/project/flask-mongoengine-3/)
- [Flask config — list of dictionaries](https://flask-mongoengine-3.readthedocs.io/en/latest/flask_config.html)
