### PR TITLE
Upgrade pillow

### DIFF
--- a/opac/tests/base.py
+++ b/opac/tests/base.py
@@ -28,7 +28,8 @@ class MongoInstance(object):
 
     def __init__(self):
         self._tmpdir = tempfile.mkdtemp()
-        self.mongo_settings = current_app.config["MONGODB_SETTINGS"]
+        settings = current_app.config["MONGODB_SETTINGS"]
+        self.mongo_settings = settings[0] if isinstance(settings, list) else settings
 
         # XXX: wait for the instance to be ready
         #      Mongo is ready in a glance, we just wait to be able to open a
@@ -75,5 +76,9 @@ class BaseTestCase(TestCase):
     def tearDown(self):
         dbsql.session.remove()
         dbsql.drop_all()
-        mongo_db_name = current_app.config["MONGODB_SETTINGS"]["db"]
+        mongo_settings = current_app.config["MONGODB_SETTINGS"]
+        if isinstance(mongo_settings, list):
+            mongo_db_name = mongo_settings[0]["db"]
+        else:
+            mongo_db_name = mongo_settings["db"]
         self.conn.drop_database(mongo_db_name)

--- a/opac/tests/test_admin_custom_filters.py
+++ b/opac/tests/test_admin_custom_filters.py
@@ -94,8 +94,13 @@ class CustomFiltersTestCase(BaseTestCase):
 
         result = filter_converter.convert("ReferenceField", Issue.journal, "journal")
         expected = [f(Issue.journal, "journal") for f in filtes_reference_field]
-
-        self.assertListEqual([vars(i) for i in expected], [vars(i) for i in result])
+        # Flask-Admin 2.2 normaliza `column` para string internamente.
+        self.assertListEqual([i.name for i in expected], [i.name for i in result])
+        self.assertListEqual([i.options for i in expected], [i.options for i in result])
+        self.assertListEqual(
+            [i.__class__.__name__ for i in expected],
+            [i.__class__.__name__ for i in result],
+        )
 
     def test_filters_list_field(self):
         filter_converter = CustomFilterConverter()
@@ -103,8 +108,12 @@ class CustomFiltersTestCase(BaseTestCase):
 
         result = filter_converter.convert("ListField", Journal.index_at, "index_at")
         expected = [f(Journal.index_at, "index_at") for f in filtes_list_field]
-
-        self.assertListEqual([vars(i) for i in expected], [vars(i) for i in result])
+        self.assertListEqual([i.name for i in expected], [i.name for i in result])
+        self.assertListEqual([i.options for i in expected], [i.options for i in result])
+        self.assertListEqual(
+            [i.__class__.__name__ for i in expected],
+            [i.__class__.__name__ for i in result],
+        )
 
     def test_custom_filter_not_equal(self):
         journal = makeOneJournal({"title": "title-%s" % str(uuid4().hex)})

--- a/opac/tests/test_tasks.py
+++ b/opac/tests/test_tasks.py
@@ -1,0 +1,94 @@
+# coding: utf-8
+
+from unittest.mock import Mock, patch
+
+from webapp import tasks
+
+from .base import BaseTestCase
+
+
+class TasksTestCase(BaseTestCase):
+    @patch("webapp.tasks.Scheduler")
+    @patch("webapp.tasks.Queue")
+    @patch("webapp.tasks.Redis")
+    def test_get_scheduler_builds_queue_and_scheduler(
+        self, mock_redis_cls, mock_queue_cls, mock_scheduler_cls
+    ):
+        redis_conn = Mock(name="redis_conn")
+        queue = Mock(name="queue")
+        scheduler = Mock(name="scheduler")
+        mock_redis_cls.return_value = redis_conn
+        mock_queue_cls.return_value = queue
+        mock_scheduler_cls.return_value = scheduler
+
+        result = tasks.get_scheduler("mailing")
+
+        mock_redis_cls.assert_called_once_with(
+            **self.app.config["RQ_REDIS_SETTINGS"]
+        )
+        mock_queue_cls.assert_called_once_with("mailing", connection=redis_conn)
+        mock_scheduler_cls.assert_called_once_with(
+            queue=queue, connection=redis_conn
+        )
+        self.assertIs(result, scheduler)
+
+    @patch("webapp.tasks.get_scheduler")
+    def test_setup_scheduler_registers_cron_job(self, mock_get_scheduler):
+        scheduler = Mock()
+        mock_get_scheduler.return_value = scheduler
+        task_function = Mock(name="task_function")
+        original_timeout = self.app.config.get("DEFAULT_SCHEDULER_TIMEOUT")
+        self.app.config["DEFAULT_SCHEDULER_TIMEOUT"] = 42
+
+        try:
+            tasks.setup_scheduler(task_function, "mailing", "0 7 * * *")
+        finally:
+            self.app.config["DEFAULT_SCHEDULER_TIMEOUT"] = original_timeout
+
+        mock_get_scheduler.assert_called_once_with("mailing")
+        scheduler.cron.assert_called_once_with(
+            "0 7 * * *",
+            func=task_function,
+            queue_name="mailing",
+            timeout=42,
+        )
+
+    @patch("webapp.tasks.get_scheduler")
+    def test_clear_scheduler_cancels_only_jobs_from_queue(self, mock_get_scheduler):
+        scheduler = Mock()
+        matching_job = Mock(id="job-1", origin="mailing")
+        other_job = Mock(id="job-2", origin="other")
+        scheduler.get_jobs.return_value = [matching_job, other_job]
+        mock_get_scheduler.return_value = scheduler
+
+        with patch("builtins.print") as mock_print:
+            tasks.clear_scheduler("mailing")
+
+        mock_get_scheduler.assert_called_once_with("mailing")
+        scheduler.get_jobs.assert_called_once_with()
+        scheduler.cancel.assert_called_once_with(matching_job)
+        mock_print.assert_called_once_with("removendo job job-1 do scheduler")
+
+    @patch("webapp.tasks.get_scheduler")
+    def test_clear_scheduler_does_nothing_when_no_matching_jobs(
+        self, mock_get_scheduler
+    ):
+        scheduler = Mock()
+        scheduler.get_jobs.return_value = [Mock(id="job-2", origin="other")]
+        mock_get_scheduler.return_value = scheduler
+
+        with patch("builtins.print") as mock_print:
+            tasks.clear_scheduler("mailing")
+
+        scheduler.cancel.assert_not_called()
+        mock_print.assert_not_called()
+
+    @patch("webapp.tasks.get_scheduler")
+    def test_clear_scheduler_with_empty_job_list(self, mock_get_scheduler):
+        scheduler = Mock()
+        scheduler.get_jobs.return_value = []
+        mock_get_scheduler.return_value = scheduler
+
+        tasks.clear_scheduler("mailing")
+
+        scheduler.cancel.assert_not_called()

--- a/opac/tests/test_utils.py
+++ b/opac/tests/test_utils.py
@@ -1,10 +1,14 @@
 # coding: utf-8
 
+import os
+import tempfile
 from unittest.mock import Mock, patch
 
 import webapp
 from flask import current_app
+from PIL import Image
 from webapp import utils as wutils
+from webapp.utils.utils import thumbgen_filename
 
 from . import utils
 from .base import BaseTestCase
@@ -443,3 +447,79 @@ class UtilsTestCase(BaseTestCase):
             '<a href="http://www.scielo.br/avaliacao/avaliacao_en.htm"></a>',
             new_content,
         )
+
+    def test_generate_thumbnail_success(self):
+        image_root = tempfile.mkdtemp()
+        original_image_root = current_app.config.get("IMAGE_ROOT")
+        original_h = current_app.config.get("THUMBNAIL_HEIGHT")
+        original_w = current_app.config.get("THUMBNAIL_WIDTH")
+        current_app.config["IMAGE_ROOT"] = image_root
+        current_app.config["THUMBNAIL_HEIGHT"] = 50
+        current_app.config["THUMBNAIL_WIDTH"] = 50
+
+        source_path = os.path.join(image_root, "sample.png")
+        Image.new("RGB", (200, 200), color="red").save(source_path)
+
+        try:
+            thumb_path = wutils.generate_thumbnail(source_path)
+            expected = os.path.join(image_root, thumbgen_filename(source_path))
+            self.assertEqual(expected, thumb_path)
+            self.assertTrue(os.path.isfile(thumb_path))
+            with Image.open(thumb_path) as thumb:
+                self.assertLessEqual(max(thumb.size), 50)
+        finally:
+            current_app.config["IMAGE_ROOT"] = original_image_root
+            current_app.config["THUMBNAIL_HEIGHT"] = original_h
+            current_app.config["THUMBNAIL_WIDTH"] = original_w
+
+    @patch("webapp.utils.utils.Image")
+    def test_generate_thumbnail_uses_lanczos(self, mocked_image_module):
+        image_root = tempfile.mkdtemp()
+        original_image_root = current_app.config.get("IMAGE_ROOT")
+        original_h = current_app.config.get("THUMBNAIL_HEIGHT")
+        original_w = current_app.config.get("THUMBNAIL_WIDTH")
+        current_app.config["IMAGE_ROOT"] = image_root
+        current_app.config["THUMBNAIL_HEIGHT"] = 100
+        current_app.config["THUMBNAIL_WIDTH"] = 100
+
+        mocked_img = Mock()
+        mocked_image_module.open.return_value = mocked_img
+        mocked_image_module.Resampling.LANCZOS = Image.Resampling.LANCZOS
+
+        try:
+            result = wutils.generate_thumbnail("/tmp/fake.png")
+            mocked_img.thumbnail.assert_called_once_with(
+                (100, 100), Image.Resampling.LANCZOS
+            )
+            mocked_img.save.assert_called_once()
+            self.assertIsNotNone(result)
+        finally:
+            current_app.config["IMAGE_ROOT"] = original_image_root
+            current_app.config["THUMBNAIL_HEIGHT"] = original_h
+            current_app.config["THUMBNAIL_WIDTH"] = original_w
+
+    @patch("webapp.utils.utils.Image")
+    def test_generate_thumbnail_io_error_returns_none(self, mocked_image_module):
+        image_root = tempfile.mkdtemp()
+        original_image_root = current_app.config.get("IMAGE_ROOT")
+        current_app.config["IMAGE_ROOT"] = image_root
+        mocked_image_module.open.side_effect = IOError("cannot open")
+
+        try:
+            self.assertIsNone(wutils.generate_thumbnail("/tmp/missing.png"))
+        finally:
+            current_app.config["IMAGE_ROOT"] = original_image_root
+
+    @patch("webapp.utils.utils.Image")
+    def test_generate_thumbnail_unexpected_error_returns_none(
+        self, mocked_image_module
+    ):
+        image_root = tempfile.mkdtemp()
+        original_image_root = current_app.config.get("IMAGE_ROOT")
+        current_app.config["IMAGE_ROOT"] = image_root
+        mocked_image_module.open.side_effect = RuntimeError("boom")
+
+        try:
+            self.assertIsNone(wutils.generate_thumbnail("/tmp/broken.png"))
+        finally:
+            current_app.config["IMAGE_ROOT"] = original_image_root

--- a/opac/webapp/__init__.py
+++ b/opac/webapp/__init__.py
@@ -239,10 +239,10 @@ def create_app():
     )
     admin.add_view(views.NewsAdminView(News, name=lazy_gettext("Notícias")))
     admin.add_view(
-        views.FileAdminView(File, dbsql.session, category=lazy_gettext("Ativos"))
+        views.FileAdminView(File, dbsql, category=lazy_gettext("Ativos"))
     )
     admin.add_view(
-        views.ImageAdminView(Image, dbsql.session, category=lazy_gettext("Ativos"))
+        views.ImageAdminView(Image, dbsql, category=lazy_gettext("Ativos"))
     )
     admin.add_view(views.PagesAdminView(Pages, name=lazy_gettext("Páginas")))
     admin.add_view(
@@ -255,7 +255,7 @@ def create_app():
     admin.add_view(
         views.UserAdminView(
             User,
-            dbsql.session,
+            dbsql,
             category=lazy_gettext("Gestão"),
             name=lazy_gettext("Usuário"),
         )

--- a/opac/webapp/admin/custom_filters.py
+++ b/opac/webapp/admin/custom_filters.py
@@ -135,6 +135,15 @@ class CustomFilterConverter(FilterConverter):
         CustomFilterInList,
         CustomFilterNotInList,
     )
+    string_filters = (
+        CustomFilterLike,
+        CustomFilterNotLike,
+        CustomFilterEqual,
+        CustomFilterNotEqual,
+        CustomFilterEmpty,
+        CustomFilterInList,
+        CustomFilterNotInList,
+    )
     embedded_filters = (
         CustomFilterLike,
         CustomFilterNotLike,
@@ -149,6 +158,12 @@ class CustomFilterConverter(FilterConverter):
     @filters.convert("ReferenceField")
     def conv_reference(self, column, name):
         return [f(column, name) for f in self.reference_filters]
+
+    @filters.convert("StringField")
+    @filters.convert("URLField")
+    @filters.convert("EmailField")
+    def conv_string(self, column, name):
+        return [f(column, name) for f in self.string_filters]
 
     @filters.convert("EmbeddedDocumentField")
     def conv_embedded(self, column, name):

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -12,7 +12,7 @@ import ast
       - http://flask.pocoo.org/docs/0.10/config/#builtin-configuration-values
       - https://pythonhosted.org/flask-mail/#configuring-flask-mail
       - http://flask-sqlalchemy.pocoo.org/2.1/config/
-      - https://flask-mongoengine.readthedocs.org/en/latest/#configuration
+      - https://flask-mongoengine-3.readthedocs.io/en/latest/flask_config.html
 
   Para ajustar configurações, pode definir as variáveis de ambiente (ver abaixo) no seu host,
   ou copie o template que melhor se ajuste a seu ambiente, e apontando o caminho absoluto
@@ -279,15 +279,18 @@ MONGODB_PORT = os.environ.get("OPAC_MONGODB_PORT", 27017)
 MONGODB_USER = os.environ.get("OPAC_MONGODB_USER", None)
 MONGODB_PASS = os.environ.get("OPAC_MONGODB_PASS", None)
 
-MONGODB_SETTINGS = {
-    "db": MONGODB_NAME,
-    "host": MONGODB_HOST,
-    "port": int(MONGODB_PORT),
-}
+MONGODB_SETTINGS = [
+    {
+        "db": MONGODB_NAME,
+        "host": MONGODB_HOST,
+        "port": int(MONGODB_PORT),
+        "alias": "default",
+    }
+]
 
 if MONGODB_USER and MONGODB_PASS:
-    MONGODB_SETTINGS["username"] = MONGODB_USER
-    MONGODB_SETTINGS["password"] = MONGODB_PASS
+    MONGODB_SETTINGS[0]["username"] = MONGODB_USER
+    MONGODB_SETTINGS[0]["password"] = MONGODB_PASS
 
 
 # Configurações do banco de dados SQL

--- a/opac/webapp/config/templates/development.template
+++ b/opac/webapp/config/templates/development.template
@@ -75,15 +75,18 @@ MONGODB_PORT = 27017
 # MONGODB_USER = os.environ.get('OPAC_MONGODB_USER', None)
 # MONGODB_PASS = os.environ.get('OPAC_MONGODB_PASS', None)
 
-MONGODB_SETTINGS = {
-    'db': MONGODB_NAME,
-    'host': MONGODB_HOST,
-    'port': int(MONGODB_PORT),
-}
+MONGODB_SETTINGS = [
+    {
+        'db': MONGODB_NAME,
+        'host': MONGODB_HOST,
+        'port': int(MONGODB_PORT),
+        'alias': 'default',
+    }
+]
 
 # if MONGODB_USER and MONGODB_PASS:
-#     MONGODB_SETTINGS['username'] = MONGODB_USER
-#     MONGODB_SETTINGS['password'] = MONGODB_PASS
+#     MONGODB_SETTINGS[0]['username'] = MONGODB_USER
+#     MONGODB_SETTINGS[0]['password'] = MONGODB_PASS
 
 
 # Configurações do banco de dados SQL

--- a/opac/webapp/config/templates/testing.template
+++ b/opac/webapp/config/templates/testing.template
@@ -94,15 +94,18 @@ MONGODB_PORT = os.environ.get('OPAC_MONGODB_PORT', 27017)
 MONGODB_USER = os.environ.get('OPAC_MONGODB_USER', None)
 MONGODB_PASS = os.environ.get('OPAC_MONGODB_PASS', None)
 
-MONGODB_SETTINGS = {
-    'db': MONGODB_NAME,
-    'host': MONGODB_HOST,
-    'port': int(MONGODB_PORT),
-}
+MONGODB_SETTINGS = [
+    {
+        'db': MONGODB_NAME,
+        'host': MONGODB_HOST,
+        'port': int(MONGODB_PORT),
+        'alias': 'default',
+    }
+]
 
 # if MONGODB_USER and MONGODB_PASS:
-#     MONGODB_SETTINGS['username'] = MONGODB_USER
-#     MONGODB_SETTINGS['password'] = MONGODB_PASS
+#     MONGODB_SETTINGS[0]['username'] = MONGODB_USER
+#     MONGODB_SETTINGS[0]['password'] = MONGODB_PASS
 
 
 # Configurações do banco de dados SQL

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1585,7 +1585,7 @@ def get_user_by_id(id):
     if not isinstance(id, int):
         raise ValueError(__("Parâmetro email deve ser uma inteiro"))
 
-    return dbsql.session.query(User).get(id)
+    return dbsql.session.get(User, id)
 
 
 def set_user_email_confirmed(user):

--- a/opac/webapp/flask_compat.py
+++ b/opac/webapp/flask_compat.py
@@ -14,40 +14,9 @@ def apply_flask_23_compat():
     if _PATCHED:
         return
 
-    _patch_json_encoder()
-    _patch_flask_mongoengine_json()
     _patch_before_app_first_request()
     _PATCHED = True
     logger.debug("Applied Flask 2.3 compatibility patches.")
-
-
-def _patch_json_encoder():
-    """Restore flask.json.JSONEncoder for flask-mongoengine."""
-    import json
-
-    import flask.json as flask_json
-
-    if hasattr(flask_json, "JSONEncoder"):
-        return
-
-    class JSONEncoder(json.JSONEncoder):
-        pass
-
-    flask_json.JSONEncoder = JSONEncoder
-
-
-def _patch_flask_mongoengine_json():
-    """Fix flask-mongoengine JSONEncoder setup on Flask 2.3+."""
-    import json
-
-    import flask_mongoengine
-    import flask_mongoengine.json as me_json
-
-    def override_json_encoder(app):
-        app.json_encoder = me_json._make_encoder(json.JSONEncoder)
-
-    me_json.override_json_encoder = override_json_encoder
-    flask_mongoengine.override_json_encoder = override_json_encoder
 
 
 def _patch_before_app_first_request():

--- a/opac/webapp/models.py
+++ b/opac/webapp/models.py
@@ -90,7 +90,7 @@ def load_user(user_id):
     Retora usuário pelo id.
     Necessário para o login manager.
     """
-    return User.query.get(int(user_id))
+    return db.session.get(User, int(user_id))
 
 
 class File(db.Model):

--- a/opac/webapp/utils/utils.py
+++ b/opac/webapp/utils/utils.py
@@ -279,7 +279,7 @@ def generate_thumbnail(input_filename):
 
     try:
         img = Image.open(input_filename)
-        img.thumbnail(size)
+        img.thumbnail(size, Image.Resampling.LANCZOS)
         img.save(image_path)
     except KeyError as e:
         logger.error("%s" % e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alembic==1.14.1
 arrow==1.4.0
-async-timeout==4.0.2
+async-timeout==5.0.1
 Babel==2.18.0
 beautifulsoup4==4.15.0
 blinker==1.9.0
@@ -13,7 +13,6 @@ citeproc-py==0.9.3
 citeproc-py-styles==0.1.5
 click==8.4.2
 colorama==0.4.6
-croniter==1.3.8
 cssmin==0.2.0
 distlib==0.4.3
 dnspython==2.8.0
@@ -61,12 +60,12 @@ python-editor==1.0.4
 python-slugify==7.0.0
 pytz==2022.7.1
 raven==6.10.0
-redis==4.4.2
+redis==5.0.8
 requests==2.34.2
 requests-oauthlib==1.3.1
-rq==1.12.0
+rq==1.16.2
 rq-dashboard==0.6.1
-rq-scheduler==0.11.0
+rq-scheduler==0.13.1
 rq-scheduler-dashboard==0.0.2
 sgmllib3k==1.0.0
 six==1.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ Flask-Caching==2.4.0
 Flask-HTMLmin==2.2.1
 Flask-Login==0.6.3
 Flask-Mail==0.10.0
-flask-mongoengine==1.0.0
+flask-mongoengine-3[wtf]==1.1.0
 Flask-SQLAlchemy==3.1.1
 Flask-WTF==1.3.0
 gevent==24.11.1
@@ -43,7 +43,7 @@ legendarium==2.0.6
 lxml==5.3.0
 Mako==1.3.12
 MarkupSafe==3.0.2
-mongoengine==0.25.0
+mongoengine==0.29.3
 natsort==8.4.0
 oauthlib==3.3.1
 packaging==26.2
@@ -53,7 +53,7 @@ picles.plumber==0.11
 Pillow==9.4.0
 platformdirs==4.10.0
 pluggy==1.6.0
-pymongo==4.3.3
+pymongo==4.10.1
 pyproject_api==1.10.1
 PySocks==1.7.1
 python-dateutil==2.9.0.post0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-alembic==1.9.2
+alembic==1.14.1
 arrow==1.4.0
 async-timeout==4.0.2
 Babel==2.18.0
@@ -30,7 +30,7 @@ Flask-HTMLmin==2.2.1
 Flask-Login==0.6.3
 Flask-Mail==0.10.0
 flask-mongoengine==1.0.0
-Flask-SQLAlchemy==3.0.2
+Flask-SQLAlchemy==3.1.1
 Flask-WTF==1.3.0
 gevent==24.11.1
 greenlet==3.1.1
@@ -71,8 +71,8 @@ rq-scheduler-dashboard==0.0.2
 sgmllib3k==1.0.0
 six==1.17.0
 soupsieve==2.8.4
-SQLAlchemy==1.4.46
-SQLAlchemy-Utils==0.39.0
+SQLAlchemy==2.0.36
+SQLAlchemy-Utils==0.41.2
 text-unidecode==1.3
 tox==4.56.2
 tweepy==4.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ feedparser==6.0.12
 feedwerk==1.2.0
 filelock==3.29.6
 Flask==3.1.2
-Flask-Admin==2.0.2
+Flask-Admin==2.2.0
 Flask-Babel==4.0.0
 Flask-Caching==2.4.0
 Flask-HTMLmin==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ packaging==26.2
 passlib==1.7.4
 pbr==5.11.1
 picles.plumber==0.11
-Pillow==9.4.0
+Pillow==12.3.0
 platformdirs==4.10.0
 pluggy==1.6.0
 pymongo==4.10.1


### PR DESCRIPTION
#### O que esse PR faz?

- Atualiza `Pillow` `9.4.0` → `12.3.0`.
- Em `generate_thumbnail`, passa `Image.Resampling.LANCZOS` a `thumbnail()` (API estável pós-remoção de `Image.ANTIALIAS` no Pillow 10).
- Adiciona testes para `generate_thumbnail` (sucesso, LANCZOS, `IOError`, erro genérico).

Arquivos:

- `requirements.txt`
- `opac/webapp/utils/utils.py`
- `opac/tests/test_utils.py`

#### Onde a revisão poderia começar?

1. `requirements.txt`
2. `opac/webapp/utils/utils.py` (`generate_thumbnail`)
3. `opac/tests/test_utils.py`

#### Como este poderia ser testado manualmente?

1. Atualizar dependências:
   ```bash
   source venv/bin/activate
   pip install -r requirements.txt
   ```
2. Rodar testes:
   ```bash
   export OPAC_CONFIG="config/templates/testing.template"
   flask --app opac.app test -p "test_utils"
   make test
   ```
3. Smoke: upload de imagem no admin (thumbnail via Flask-Admin / `MediaImageUploadField`).

#### Algum cenário de contexto que queira dar?

O OPAC não usava `Image.ANTIALIAS` (removido no Pillow 10). O Flask-Admin 2.2 já usa `Resampling.LANCZOS`. O harden em `generate_thumbnail` deixa o filtro explícito e evita default variável entre versões.

### Screenshots

N/A (upgrade de dependência / thumbnail).

#### Quais são tickets relevantes?

N/A

### Referências

- [Pillow 10.0 — removed constants](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html)
