### PR TITLE
Silencia logs DEBUG do pymongo no create_app

### DIFF
--- a/opac/webapp/__init__.py
+++ b/opac/webapp/__init__.py
@@ -140,6 +140,9 @@ def create_app():
     app.config.from_object("webapp.config.default")  # Configuração basica
     app.config.from_envvar("OPAC_CONFIG", silent=True)  # configuração do ambiente
     app.logger.root.setLevel(app.config.get("LOG_LEVEL"))
+    
+    # PyMongo 4.x structured DEBUG logs flood stdout when root is DEBUG
+    logging.getLogger("pymongo").setLevel(logging.WARNING)
 
     configure_apm_agent(app)
 


### PR DESCRIPTION
## Resumo
- Silencia os loggers `pymongo.*` elevando o nível para `WARNING` em `create_app`
- Evita o volume excessivo de logs estruturados do PyMongo 4.x (`serverSelection`, `connection`, `command`) quando `OPAC_LOG_LEVEL=DEBUG`
- Mantém o `LOG_LEVEL` da aplicação e continua emitindo warnings/erros reais do driver


## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [x] Sim — link do job:
- [ ] Não aplicável a este PR (justifique):

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)