### PR TITLE
fix(press-releases): exibe imagens destacadas nos cards

### DIFF
--- a/opac/scripts/backfill_press_release_images.py
+++ b/opac/scripts/backfill_press_release_images.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+"""Fill missing PressRelease.image_url values from the WordPress REST API."""
+
+import argparse
+import os
+import re
+from urllib.parse import urlencode
+
+import requests
+from pymongo import MongoClient, UpdateOne
+
+
+POST_ID_RE = re.compile(r"[?&]p=(\d+)")
+MISSING_IMAGE = {
+    "$or": [
+        {"image_url": {"$exists": False}},
+        {"image_url": None},
+        {"image_url": ""},
+    ]
+}
+WORDPRESS_APIS = {
+    "default": "https://pressreleases.scielo.org/wp-json/wp/v2/posts",
+    "en": "https://pressreleases.scielo.org/en/wp-json/wp/v2/posts",
+}
+
+
+def chunks(items, size=100):
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+def wordpress_site(url):
+    return "en" if "/en/" in (url or "") else "default"
+
+
+def image_url(post):
+    embedded_media = post.get("_embedded", {}).get("wp:featuredmedia", [])
+    if not embedded_media:
+        return None
+
+    media = embedded_media[0]
+    # source_url is the original featured image and therefore the best
+    # quality made available by WordPress for this media item.
+    if media.get("source_url"):
+        return media["source_url"]
+
+    sizes = media.get("media_details", {}).get("sizes", {})
+    for preferred_size in ("large", "medium_large", "medium"):
+        if sizes.get(preferred_size, {}).get("source_url"):
+            return sizes[preferred_size]["source_url"]
+    return None
+
+
+def fetch_images(session, site, post_ids):
+    images = {}
+    for post_id_chunk in chunks(sorted(post_ids)):
+        query = urlencode(
+            {
+                "include": ",".join(str(post_id) for post_id in post_id_chunk),
+                "per_page": len(post_id_chunk),
+                "_embed": "wp:featuredmedia",
+                "_fields": "id,_links,_embedded",
+            }
+        )
+        response = session.get(f"{WORDPRESS_APIS[site]}?{query}", timeout=60)
+        response.raise_for_status()
+        for post in response.json():
+            url = image_url(post)
+            if url:
+                images[post["id"]] = url
+    return images
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Update MongoDB. Without this option the script is read-only.",
+    )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Re-evaluate records that already have an image URL.",
+    )
+    args = parser.parse_args()
+
+    mongo_host = os.environ.get("OPAC_MONGODB_HOST", "localhost")
+    mongo_port = int(os.environ.get("OPAC_MONGODB_PORT", "27017"))
+    mongo_name = os.environ.get("OPAC_MONGODB_NAME", "opac")
+    collection = MongoClient(mongo_host, mongo_port)[mongo_name].pressrelease
+
+    record_filter = {} if args.refresh else MISSING_IMAGE
+    records = list(collection.find(record_filter, {"url": 1, "title": 1}))
+    records_by_site_and_post = {site: {} for site in WORDPRESS_APIS}
+    without_post_id = []
+
+    for record in records:
+        match = POST_ID_RE.search(record.get("url") or "")
+        if not match:
+            without_post_id.append(record)
+            continue
+        site = wordpress_site(record.get("url"))
+        records_by_site_and_post[site].setdefault(int(match.group(1)), []).append(record)
+
+    session = requests.Session()
+    session.headers["User-Agent"] = "SciELO-OPAC/press-release-image-backfill"
+    images = {}
+    for site, records_by_post in records_by_site_and_post.items():
+        for post_id, url in fetch_images(session, site, records_by_post).items():
+            images[(site, post_id)] = url
+
+    updates = []
+    matched_documents = 0
+    for site, records_by_post in records_by_site_and_post.items():
+        for post_id, post_records in records_by_post.items():
+            url = images.get((site, post_id))
+            if not url:
+                continue
+            for record in post_records:
+                matched_documents += 1
+                update_filter = {"_id": record["_id"]}
+                if not args.refresh:
+                    update_filter.update(MISSING_IMAGE)
+                updates.append(
+                    UpdateOne(update_filter, {"$set": {"image_url": url}})
+                )
+
+    modified = 0
+    if args.apply and updates:
+        result = collection.bulk_write(updates, ordered=False)
+        modified = result.modified_count
+
+    print(f"missing_image={len(records)}")
+    print(f"matched_image={matched_documents}")
+    print(f"without_post_id={len(without_post_id)}")
+    print(f"unmatched_image={len(records) - matched_documents}")
+    print(f"modified={modified}")
+    print(f"refresh={args.refresh}")
+    print(f"mode={'apply' if args.apply else 'dry-run'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/opac/tests/test_restapi.py
+++ b/opac/tests/test_restapi.py
@@ -44,6 +44,88 @@ class RestAPIAuthMixin:
         )
 
 
+class RestAPIPressReleaseTestCase(RestAPIAuthMixin, BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.journal = makeOneJournal()
+        self.payload = {
+            "journal_id": self.journal.id,
+            "title": "Press release title",
+            "language": "pt_BR",
+            "doi": "10.1234/press.release",
+            "content": "Press release content",
+            "url": "https://pressreleases.scielo.org/?p=123",
+            "publication_date": "2026-07-14T15:00:32",
+        }
+
+    def test_add_press_release_with_feedparser_media_content(self):
+        self.payload["media_content"] = [
+            {
+                "url": "https://cdn.example.org/image.png",
+                "medium": "image",
+            }
+        ]
+
+        with current_app.app_context():
+            with self.client as client:
+                response = self._api_post(
+                    client, "restapi.pressrelease", self.payload
+                )
+
+            self.assertEqual(response.status_code, 200)
+            press_release = models.PressRelease.objects(url=self.payload["url"]).get()
+            self.assertEqual(
+                press_release.image_url, "https://cdn.example.org/image.png"
+            )
+
+    def test_add_press_release_uses_original_wordpress_featured_image(self):
+        self.payload["media_content"] = [
+            {
+                "url": (
+                    "https://pressreleases-scielo.b-cdn.net/wp-content/"
+                    "uploads/2026/07/featured-image-300x170.png"
+                )
+            }
+        ]
+
+        with current_app.app_context():
+            with self.client as client:
+                response = self._api_post(
+                    client, "restapi.pressrelease", self.payload
+                )
+
+            self.assertEqual(response.status_code, 200)
+            press_release = models.PressRelease.objects(url=self.payload["url"]).get()
+            self.assertEqual(
+                press_release.image_url,
+                (
+                    "https://pressreleases-scielo.b-cdn.net/wp-content/"
+                    "uploads/2026/07/featured-image.png"
+                ),
+            )
+
+    def test_reprocessing_updates_image_without_creating_duplicate(self):
+        with current_app.app_context():
+            with self.client as client:
+                first_response = self._api_post(
+                    client, "restapi.pressrelease", self.payload
+                )
+                self.payload["media_content"] = {
+                    "url": "https://cdn.example.org/image.png"
+                }
+                second_response = self._api_post(
+                    client, "restapi.pressrelease", self.payload
+                )
+
+            self.assertEqual(first_response.status_code, 200)
+            self.assertEqual(second_response.status_code, 200)
+            records = models.PressRelease.objects(url=self.payload["url"])
+            self.assertEqual(records.count(), 1)
+            self.assertEqual(
+                records.get().image_url, "https://cdn.example.org/image.png"
+            )
+
+
 class RestAPIJournalTestCase(RestAPIAuthMixin, BaseTestCase):
     def load_json_fixture(self, filename):
         with open(os.path.join(FIXTURES_PATH, filename)) as f:

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1544,7 +1544,23 @@ def create_news_record(news_model_data):
 
 def create_press_release_record(pr_model_data):
     try:
-        pr = PressRelease.objects(**pr_model_data)[:1]
+        # A URL identifica o post no WordPress. Procurar por todos os campos
+        # impedia a atualização quando, por exemplo, a imagem era adicionada
+        # posteriormente e acabava criando um novo registro.
+        if pr_model_data.get("url"):
+            lookup = {
+                "url": pr_model_data["url"],
+                "language": pr_model_data.get("language"),
+            }
+        elif pr_model_data.get("doi"):
+            lookup = {
+                "doi": pr_model_data["doi"],
+                "language": pr_model_data.get("language"),
+            }
+        else:
+            # Mantém o comportamento anterior para payloads legados sem URL/DOI.
+            lookup = pr_model_data
+        pr = PressRelease.objects(**lookup)[:1]
 
         if len(pr) == 0:  # On create add an id
             pr_model_data["_id"] = uuid4().hex

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -2229,9 +2229,11 @@ def pressrelease(*args):
         "doi": payload.get("doi"),
         "content": payload.get("content"),
         "url": payload.get("url"),
-        "image_url": payload.get("media_content"),
         "publication_date": payload.get("publication_date"),
     }
+    image_url = _get_press_release_image_url(payload)
+    if image_url:
+        data["image_url"] = image_url
 
     try:
         create_press_release_record(pr_model_data=data)
@@ -2239,6 +2241,50 @@ def pressrelease(*args):
         return jsonify({"failed": True, "error": str(e)}), 500
     else:
         return jsonify({"failed": False}), 200
+
+
+def _get_press_release_image_url(payload):
+    """Return a URL from the common WordPress/RSS media payload formats."""
+    media = (
+        payload.get("media_content")
+        or payload.get("media:content")
+        or payload.get("image_url")
+    )
+
+    if isinstance(media, str):
+        return _wordpress_original_image_url(media)
+
+    if isinstance(media, dict):
+        return _wordpress_original_image_url(media.get("url") or media.get("href"))
+
+    if isinstance(media, (list, tuple)):
+        for item in media:
+            if isinstance(item, str) and item:
+                return _wordpress_original_image_url(item)
+            if isinstance(item, dict):
+                url = item.get("url") or item.get("href")
+                if url:
+                    return _wordpress_original_image_url(url)
+
+    return None
+
+
+def _wordpress_original_image_url(url):
+    """Convert a generated WordPress thumbnail URL to its original file URL."""
+    if not url:
+        return None
+
+    parsed_url = urlparse(url)
+    if not (
+        parsed_url.hostname == "pressreleases.scielo.org"
+        or parsed_url.hostname == "pressreleases-scielo.b-cdn.net"
+    ):
+        return url
+
+    original_path = re.sub(
+        r"-\d+x\d+(?=\.[A-Za-z0-9]+$)", "", parsed_url.path
+    )
+    return parsed_url._replace(path=original_path).geturl()
 
 
 @restapi.route("/journal_last_issues", methods=["POST", "PUT"])


### PR DESCRIPTION

## O que esse PR faz?
- normaliza os formatos de mídia recebidos do feed WordPress
- utiliza a imagem destacada original quando disponível
- evita duplicidades durante o reprocessamento
- adiciona backfill para registros existentes sem image_url
- inclui testes para importação e atualização das imagens

Fale sobre o propósito do pull request, como por exemplo: quais problemas ele soluciona ou quais features ele adiciona.
Resolve a não exibição de imagens dos posts do blog press release na home do opac5.

## Onde a revisão poderia começar?
A revisão pode começar em:
opac/webapp/main/views.py
Mais especificamente, no endpoint pressrelease() e nas funções auxiliares _get_press_release_image_url() e _wordpress_original_image_url().
Depois, recomenda-se revisar:
opac/webapp/controllers.py: lógica de atualização sem duplicar registros.
opac/scripts/backfill_press_release_images.py: reprocessamento dos registros existentes.
opac/tests/test_restapi.py: cenários automatizados adicionados.

Indique o caminho do arquivo e o arquivo onde o revisor deve iniciar a leitura do código.
opac/webapp/main/views.py
opac/webapp/controllers.py
opac/scripts/backfill_press_release_images.py
opac/tests/test_restapi.py

## Como este poderia ser testado manualmente?
1 - Inicie o OPAC5 e o MongoDB localmente.

2 - Execute o backfill em modo de prévia:

python opac/scripts/backfill_press_release_images.py

3 - Confira os valores exibidos para matched_image, unmatched_image e modified. No modo de prévia, modified deve permanecer igual a zero.

4 - Aplique as atualizações:
python opac/scripts/backfill_press_release_images.py --apply

5 - Para substituir thumbnails existentes pela imagem destacada original, execute:
python opac/scripts/backfill_press_release_images.py --refresh --apply

6 - Acesse a página inicial local e localize a seção “Brasil Press Releases”.

7 - Verifique que:
os cards utilizam as imagens destacadas dos respectivos posts;
os cards com imagem disponível não exibem mais a ilustração genérica;
os links e títulos continuam correspondendo ao Press Release correto;
as imagens não estão sendo obtidas arbitrariamente do conteúdo do post.

8 - Reprocesse o mesmo feed novamente e confirme que não foram criados registros duplicados.

9 - Opcionalmente, consulte o MongoDB:

db.pressrelease.countDocuments({
  image_url: { $exists: true, $nin: [null, ""] }
})

Estabeleça os passos necessários para que a funcionalidade seja testada manualmente pelo revisor.

## Algum cenário de contexto que queira dar?
O feed do WordPress já fornecia corretamente as imagens destacadas em media:content. Entretanto, bibliotecas como o feedparser normalmente representam esse campo como uma lista de objetos, enquanto o endpoint do OPAC5 esperava apenas uma string.
Como consequência, image_url não era preenchido e o template exibia a imagem genérica de fallback.
O ajuste normaliza os diferentes formatos possíveis, preserva exclusivamente a imagem destacada e utiliza o arquivo original quando o WordPress fornece uma URL de thumbnail. A lógica de persistência também passou a localizar registros por URL ou DOI e idioma, permitindo o reprocessamento sem duplicidades.
Para os registros históricos, foi incluído um backfill em modo seguro: sem --apply, ele apenas apresenta uma prévia. Posts que não possuem imagem destacada no WordPress permanecem usando o fallback existente.

Indique um contexto onde as modificações se fazem necessárias ou passe informações que contextualizam o revisor a fim de facilitar o entendimento da funcionalidade.

## Screenshots
<img width="1430" height="1005" alt="Screen Shot 2026-07-22 at 10 15 39" src="https://github.com/user-attachments/assets/c3c7000a-0433-4d04-b2f1-3058d972952d" />


Quando aplicável e se fizer possível, adicione screenshots que remetem à situação gráfica do problema que o pull request resolve.

## Quais são os tickets relevantes?
-

Indique uma issue à qual o pull request faz relacionamento.

## Referências

Indique as referências utilizadas para a elaboração do pull request.

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique):

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [ ] Não, nenhum segredo foi commitado
- [x] Sim (bloquear merge e corrigir antes de prosseguir)