### PR TITLE
Corrige filtros MongoEngine com Flask-Admin 2.2

### DIFF
--- a/opac/tests/test_admin_custom_filters.py
+++ b/opac/tests/test_admin_custom_filters.py
@@ -5,8 +5,8 @@ from uuid import uuid4
 from flask_admin.contrib.mongoengine.tools import parse_like_term
 from flask_babel import lazy_gettext as __
 from mongoengine.queryset import Q
-from opac_schema.v1.models import Article, Issue, Journal
-from tests.utils import makeOneArticle, makeOneIssue, makeOneJournal
+from opac_schema.v1.models import Article, Issue, Journal, Pages
+from tests.utils import makeOneArticle, makeOneIssue, makeOneJournal, makeOnePage
 from webapp.admin.custom_filters import (
     CustomFilterConverter,
     CustomFilterEmpty,
@@ -16,6 +16,7 @@ from webapp.admin.custom_filters import (
     CustomFilterNotEqual,
     CustomFilterNotInList,
     CustomFilterNotLike,
+    _column_name,
     get_flt,
 )
 
@@ -23,6 +24,10 @@ from .base import BaseTestCase
 
 
 class CustomFiltersTestCase(BaseTestCase):
+    def test_column_name_accepts_field_and_str(self):
+        self.assertEqual(_column_name(Pages.name), "name")
+        self.assertEqual(_column_name("name"), "name")
+
     def test_flt_reference_journal(self):
         journal_fields = {
             "title": "title-%s" % str(uuid4().hex),
@@ -81,6 +86,15 @@ class CustomFiltersTestCase(BaseTestCase):
 
         self.assertEqual(expected.query, result.query)
 
+    def test_flt_string_column_name(self):
+        """Flask-Admin 2.2 may pass column as str (reproduces /admin/pages/ crash)."""
+        op, term = parse_like_term("page-%s" % str(uuid4().hex))
+
+        result = get_flt("name", term, op)
+
+        expected = Q(**{"name__%s" % op: term})
+        self.assertEqual(expected.query, result.query)
+
     def test_filters_reference_field(self):
         filter_converter = CustomFilterConverter()
         filtes_reference_field = (
@@ -94,13 +108,14 @@ class CustomFiltersTestCase(BaseTestCase):
 
         result = filter_converter.convert("ReferenceField", Issue.journal, "journal")
         expected = [f(Issue.journal, "journal") for f in filtes_reference_field]
-        # Flask-Admin 2.2 normaliza `column` para string internamente.
         self.assertListEqual([i.name for i in expected], [i.name for i in result])
         self.assertListEqual([i.options for i in expected], [i.options for i in result])
         self.assertListEqual(
             [i.__class__.__name__ for i in expected],
             [i.__class__.__name__ for i in result],
         )
+        # Field object must be preserved for ReferenceField filtering.
+        self.assertTrue(all(i.column is Issue.journal for i in result))
 
     def test_filters_list_field(self):
         filter_converter = CustomFilterConverter()
@@ -114,6 +129,59 @@ class CustomFiltersTestCase(BaseTestCase):
             [i.__class__.__name__ for i in expected],
             [i.__class__.__name__ for i in result],
         )
+
+    def test_filters_string_field_keeps_field_object(self):
+        filter_converter = CustomFilterConverter()
+        result = filter_converter.convert("StringField", Pages.name, "Nome")
+
+        self.assertTrue(result)
+        self.assertTrue(all(i.column is Pages.name for i in result))
+        self.assertIn(CustomFilterLike, [type(i) for i in result])
+
+    def test_custom_filter_like_with_string_column(self):
+        page_name = "page-%s" % str(uuid4().hex)
+        makeOnePage({"name": page_name})
+        custom_filter = CustomFilterLike(column="name", name=__("Nome"))
+
+        result = custom_filter.apply(Pages.objects, page_name)
+
+        term, data = parse_like_term(page_name)
+        expected = Pages.objects.filter(Q(**{"name__%s" % term: data}))
+
+        self.assertListEqual([_ for _ in expected], [_ for _ in result])
+
+    def test_custom_filter_like_via_converter_on_pages(self):
+        """End-to-end path used by PagesAdminView column_filters."""
+        page_name = "page-%s" % str(uuid4().hex)
+        makeOnePage({"name": page_name})
+
+        filters = CustomFilterConverter().convert("StringField", Pages.name, "Nome")
+        like_filter = next(f for f in filters if isinstance(f, CustomFilterLike))
+
+        result = like_filter.apply(Pages.objects, page_name)
+
+        term, data = parse_like_term(page_name)
+        expected = Pages.objects.filter(Q(**{"name__%s" % term: data}))
+        self.assertListEqual([_ for _ in expected], [_ for _ in result])
+
+    def test_custom_filter_equal_with_string_column(self):
+        page_name = "page-%s" % str(uuid4().hex)
+        makeOnePage({"name": page_name})
+        custom_filter = CustomFilterEqual(column="name", name=__("Nome"))
+
+        result = custom_filter.apply(Pages.objects, page_name)
+        expected = Pages.objects.filter(Q(name=page_name))
+
+        self.assertListEqual([_ for _ in expected], [_ for _ in result])
+
+    def test_custom_filter_empty_with_string_column(self):
+        makeOnePage({"name": "filled-%s" % str(uuid4().hex)})
+        custom_filter = CustomFilterEmpty(column="description", name=__("Descrição"))
+
+        result = custom_filter.apply(Pages.objects, "1")
+        expected = Pages.objects.filter(Q(description=None))
+
+        self.assertListEqual([_ for _ in expected], [_ for _ in result])
 
     def test_custom_filter_not_equal(self):
         journal = makeOneJournal({"title": "title-%s" % str(uuid4().hex)})

--- a/opac/webapp/admin/custom_filters.py
+++ b/opac/webapp/admin/custom_filters.py
@@ -19,6 +19,11 @@ from opac_schema.v1.models import Issue, Journal
 from webapp import models
 
 
+def _column_name(column):
+    """Flask-Admin 2.2 may pass field name (str) instead of a MongoEngine field."""
+    return column if isinstance(column, str) else column.name
+
+
 def get_flt(column=None, value=None, term=""):
     flt = None
     search_fields = {
@@ -34,10 +39,12 @@ def get_flt(column=None, value=None, term=""):
         "use_licenses": ["license_code", "reference_url", "disclaimer"],
     }
 
+    col_name = _column_name(column)
+
     if isinstance(column, ReferenceField):
         criteria = None
         reference_values = None
-        for field in search_fields[column.name]:
+        for field in search_fields[col_name]:
             flt = {"%s__%s" % (field, term): value}
             q = Q(**flt)
 
@@ -51,12 +58,12 @@ def get_flt(column=None, value=None, term=""):
             reference_values = Journal.objects.filter(criteria)
         if isinstance(column.document_type_obj(), Issue):
             reference_values = Issue.objects.filter(criteria)
-        flt = {"%s__in" % column.name: reference_values}
+        flt = {"%s__in" % col_name: reference_values}
 
     elif isinstance(column, EmbeddedDocumentField):
         criteria = None
-        for field in search_fields[column.name]:
-            flt = {"%s__%s__%s" % (column.name, field, term): value}
+        for field in search_fields[col_name]:
+            flt = {"%s__%s__%s" % (col_name, field, term): value}
             q = Q(**flt)
 
             if criteria is None:
@@ -68,10 +75,10 @@ def get_flt(column=None, value=None, term=""):
         return criteria
 
     elif isinstance(column, ListField) and isinstance(column.field, StringField):
-        flt = {"%s__%s" % (column.name, term): value if value else []}
+        flt = {"%s__%s" % (col_name, term): value if value else []}
 
     else:
-        flt = {"%s__%s" % (column.name, term): value}
+        flt = {"%s__%s" % (col_name, term): value}
 
     return Q(**flt)
 
@@ -155,6 +162,34 @@ class CustomFilterConverter(FilterConverter):
     )
     list_filters = (CustomFilterLike, CustomFilterNotLike, CustomFilterEmpty)
 
+    def convert(self, type_name, column, name):
+        """
+        Preserve MongoEngine field objects for our custom converters.
+
+        Flask-Admin 2.2's FilterConverter.convert() passes column.name (str) to
+        registered converters. Built-in filters expect a string; our get_flt()
+        needs the field for ReferenceField / EmbeddedDocumentField / ListField.
+        """
+        filter_name = type_name.lower()
+        if filter_name not in self.converters:
+            return None
+
+        # Types handled by CustomFilter* (need field object metadata).
+        custom_field_types = {
+            "referencefield",
+            "stringfield",
+            "urlfield",
+            "emailfield",
+            "embeddeddocumentfield",
+            "listfield",
+        }
+        if filter_name in custom_field_types:
+            return self.converters[filter_name](column, name)
+
+        # Built-in Flask-Admin filters expect column as str.
+        col = column if isinstance(column, str) else column.name
+        return self.converters[filter_name](col, name)
+
     @filters.convert("ReferenceField")
     def conv_reference(self, column, name):
         return [f(column, name) for f in self.reference_filters]
@@ -190,5 +225,5 @@ class CustomFilterConverterSqla(sqla.filters.FilterConverter):
     @filters.convert("ChoiceType")
     def conv_choice(self, column, name, options):
         if not options:
-            options = self.choices[column.name]
+            options = self.choices[_column_name(column)]
         return [f(column, name, options) for f in self.choice_filters]


### PR DESCRIPTION
## O que esse PR faz?

Corrige o `AttributeError: 'str' object has no attribute 'name'` ao aplicar filtros no Flask-Admin MongoEngine (ex.: `/admin/pages/`).

No Flask-Admin 2.2, `FilterConverter.convert()` passa o nome do campo como `str`, enquanto `get_flt()` ainda assumia um field MongoEngine (`.name`). O PR:

- adiciona `_column_name()` e torna `get_flt()` compatível com field ou `str`;
- ajusta `CustomFilterConverter.convert()` para preservar o field object nos filtros customizados (ReferenceField / StringField / etc.), mantendo `str` nos filtros built-in (DateTime, Boolean);
- inclui testes cobrindo o caminho que quebrava em Pages.

## Onde a revisão poderia começar?

1. `opac/webapp/admin/custom_filters.py` — `_column_name`, `get_flt`, `CustomFilterConverter.convert`
2. `opac/tests/test_admin_custom_filters.py` — casos com `column` como `str` e fluxo converter → `apply` em Pages

## Como este poderia ser testado manualmente?

1. Abrir `/admin/pages/` com filtro ativo (ex.: Name contains) — a listagem deve carregar sem HTTP 500.
2. Aplicar filtros por `name`, `language`, `journal`, `is_draft`, `created_at` e `updated_at`.
3. Em Periódicos / Números / Artigos, filtrar por ReferenceField (ex.: Periódico contains) e confirmar que a busca funciona.
4. Rodar os testes:
   ```bash
   export OPAC_CONFIG="config/templates/testing.template"
   flask --app opac.app test -p "test_admin_custom_filters"