### PR TITLE
Remove a emissão do cookie de sessão Flask `opac_session` nas páginas públicas, para permitir cache eficiente no BunnyCDN.

### DIFF
--- a/.envs/.production-template/.server
+++ b/.envs/.production-template/.server
@@ -14,8 +14,8 @@ OPAC_SESSION_COOKIE_HTTPONLY=True
 # session cookie name (default: 'opac_session')
 OPAC_SESSION_COOKIE_NAME=opac_session
 
-# path to session cookie: (default: None -> ou seja a raiz /)
-OPAC_SESSION_COOKIE_PATH=None
+# path to session cookie: (default: /admin — only sent on admin paths)
+OPAC_SESSION_COOKIE_PATH=/admin
 
 # sets whether the session cookie should be marked as secure - (default: False)
 OPAC_SESSION_COOKIE_SECURE=False

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ ALERT_MSG_ES=Nuevo portal puede contener incorrecciones
 |        OPAC_SESSION_COOKIE_DOMAIN  	|         OPAC_SERVER_NAME  	|          www.scielo.br, www.scielosp.org            	|       21/11/2021           	|        O dominio para a cookie da sessão     |
 |        OPAC_SESSION_COOKIE_HTTPONLY  	|         True  	|          True/False            	|       21/11/2021           	|        Seta a flag: httponly da cookie.     |
 |        OPAC_SESSION_COOKIE_NAME  	|         opac_session  	|          opac_session            	|       21/11/2021           	|        nome da cookie de sessão     |
-|        OPAC_SESSION_COOKIE_PATH  	|         None  	|          '/'            	|       21/11/2021           	|        path para a cookie de sessão     |
+|        OPAC_SESSION_COOKIE_PATH  	|         /admin  	|          /admin            	|       29/07/2026           	|        path para a cookie de sessão (somente admin)     |
 |        OPAC_SESSION_COOKIE_SECURE  	|         False  	|          True/False            	|       21/11/2021           	|        define se a cookie de sessão deve ser marcada como segura     |
 |        OPAC_SESSION_REFRESH_EACH_REQUEST  	|         False  	|          True/False            	|       21/11/2021           	|        Fazer refresh da cookie em cada request?     |
 |        OPAC_CACHE_ENABLED  	|         True  	|          True/False            	|       21/11/2021           	|         ativa/desativa o cache com redis    |

--- a/opac/tests/test_admin_views.py
+++ b/opac/tests/test_admin_views.py
@@ -203,9 +203,18 @@ class AdminViewsTestCase(BaseTestCase):
                     create_user(credentials["email"], credentials["password"], True)
                     # create new user:
                     response = c.post(
-                        login_url, data=credentials, follow_redirects=True
+                        login_url, data=credentials, follow_redirects=False
                     )
-                    # then
+                    # then — session cookie scoped to /admin for CDN-friendly public pages
+                    self.assertStatus(response, 302)
+                    set_cookie = "; ".join(response.headers.getlist("Set-Cookie"))
+                    cookie_name = current_app.config.get(
+                        "SESSION_COOKIE_NAME", "opac_session"
+                    )
+                    self.assertIn("%s=" % cookie_name, set_cookie)
+                    self.assertIn("Path=/admin", set_cookie)
+
+                    response = c.get(response.headers["Location"], follow_redirects=True)
                     self.assertStatus(response, 200)
                     self.assertTemplateUsed("admin/index.html")
                     self.assertIn(expected_page_header, response.data.decode("utf-8"))

--- a/opac/tests/test_glue_coverage.py
+++ b/opac/tests/test_glue_coverage.py
@@ -4,7 +4,6 @@ import importlib
 import os
 import sys
 import tempfile
-from contextlib import contextmanager
 from unittest.mock import MagicMock, Mock, patch
 
 from flask import Flask, current_app
@@ -449,18 +448,6 @@ class ModelsGlueCoverageTestCase(BaseTestCase):
 
 
 class FormsGlueCoverageTestCase(BaseTestCase):
-    @contextmanager
-    def _without_csrf(self):
-        previous = current_app.config.get("WTF_CSRF_ENABLED")
-        current_app.config["WTF_CSRF_ENABLED"] = False
-        try:
-            yield
-        finally:
-            if previous is None:
-                current_app.config.pop("WTF_CSRF_ENABLED", None)
-            else:
-                current_app.config["WTF_CSRF_ENABLED"] = previous
-
     def _valid_form_data(self, **overrides):
         data = {
             "your_email": "sender@example.com",
@@ -474,26 +461,23 @@ class FormsGlueCoverageTestCase(BaseTestCase):
 
     def test_email_share_form_valid_recipients(self):
         with self.app.test_request_context():
-            with self._without_csrf():
-                form = EmailShareForm(data=self._valid_form_data())
-                self.assertTrue(form.validate())
+            form = EmailShareForm(data=self._valid_form_data())
+            self.assertTrue(form.validate())
 
     def test_email_share_form_invalid_recipient_raises_validation_error(self):
         with self.app.test_request_context():
-            with self._without_csrf():
-                form = EmailShareForm(
-                    data=self._valid_form_data(recipients="not-an-email")
-                )
-                self.assertFalse(form.validate())
-                self.assertIn("recipients", form.errors)
+            form = EmailShareForm(
+                data=self._valid_form_data(recipients="not-an-email")
+            )
+            self.assertFalse(form.validate())
+            self.assertIn("recipients", form.errors)
 
     def test_email_share_form_ignores_empty_recipient_segments(self):
         with self.app.test_request_context():
-            with self._without_csrf():
-                form = EmailShareForm(
-                    data=self._valid_form_data(recipients="one@example.com;; ")
-                )
-                self.assertTrue(form.validate())
+            form = EmailShareForm(
+                data=self._valid_form_data(recipients="one@example.com;; ")
+            )
+            self.assertTrue(form.validate())
 
     def test_email_share_form_validate_recipients_direct_invalid(self):
         form = EmailShareForm()
@@ -501,6 +485,13 @@ class FormsGlueCoverageTestCase(BaseTestCase):
         field.data = "bad-email"
         with self.assertRaises(ValidationError):
             EmailShareForm.validate_recipients(form, field)
+
+    def test_public_forms_disable_csrf(self):
+        from webapp.forms import ContactForm, ErrorForm
+
+        self.assertFalse(EmailShareForm.Meta.csrf)
+        self.assertFalse(ContactForm.Meta.csrf)
+        self.assertFalse(ErrorForm.Meta.csrf)
 
 
 class ExceptionsGlueCoverageTestCase(BaseTestCase):

--- a/opac/tests/test_main_views_coverage.py
+++ b/opac/tests/test_main_views_coverage.py
@@ -4,7 +4,6 @@
 import json
 import os
 import tempfile
-from contextlib import contextmanager
 from io import BytesIO
 from unittest.mock import MagicMock, Mock, patch
 
@@ -27,7 +26,15 @@ from .base import BaseTestCase
 from .test_restapi import RestAPIAuthMixin
 
 
-AJAX_HEADERS = {"X-Requested-With": "XMLHttpRequest"}
+def ajax_headers(**extra):
+    """XHR headers with Origin matching the test app SERVER_NAME."""
+    server_name = current_app.config.get("SERVER_NAME") or "localhost"
+    headers = {
+        "X-Requested-With": "XMLHttpRequest",
+        "Origin": "http://%s" % server_name,
+    }
+    headers.update(extra)
+    return headers
 
 
 class MainViewsCoverageMixin(object):
@@ -355,7 +362,7 @@ class JournalSearchAjaxCoverageTests(MainViewsCoverageMixin, BaseTestCase):
             utils.makeOneJournal()
             response = self.client.get(
                 url_for("main.journals_search_alpha_ajax"),
-                headers=AJAX_HEADERS,
+                headers=ajax_headers(),
             )
             self.assertStatus(response, 200)
 
@@ -364,7 +371,7 @@ class JournalSearchAjaxCoverageTests(MainViewsCoverageMixin, BaseTestCase):
             response = self.client.get(
                 url_for("main.journals_search_by_theme_ajax"),
                 query_string={"filter": "invalid"},
-                headers=AJAX_HEADERS,
+                headers=ajax_headers(),
             )
             self.assertStatus(response, 200)
             data = response.get_json()
@@ -378,40 +385,27 @@ class JournalSearchAjaxCoverageTests(MainViewsCoverageMixin, BaseTestCase):
                 response = self.client.get(
                     url_for("main.journals_search_by_theme_ajax"),
                     query_string={"filter": filter_name},
-                    headers=AJAX_HEADERS,
+                    headers=ajax_headers(),
                 )
                 self.assertStatus(response, 200)
 
 
 class ContactAndEmailCoverageTests(MainViewsCoverageMixin, BaseTestCase):
-    @contextmanager
-    def _without_csrf(self):
-        previous = current_app.config.get("WTF_CSRF_ENABLED")
-        current_app.config["WTF_CSRF_ENABLED"] = False
-        try:
-            yield
-        finally:
-            if previous is None:
-                current_app.config.pop("WTF_CSRF_ENABLED", None)
-            else:
-                current_app.config["WTF_CSRF_ENABLED"] = previous
-
     @patch("webapp.main.views.controllers.send_email_contact")
     @patch("webapp.main.views.utils.is_recaptcha_valid", return_value=True)
     def test_contact_ajax_success(self, _recaptcha, mock_send):
         mock_send.return_value = (True, "sent")
         with current_app.app_context():
             journal = utils.makeOneJournal({"enable_contact": True, "editor_email": "e@x.com"})
-            with self._without_csrf():
-                response = self.client.post(
-                    url_for("main.contact", url_seg=journal.url_segment),
-                    headers=AJAX_HEADERS,
-                    data={
-                        "name": "User",
-                        "your_email": "user@example.com",
-                        "message": "Hello",
-                    },
-                )
+            response = self.client.post(
+                url_for("main.contact", url_seg=journal.url_segment),
+                headers=ajax_headers(),
+                data={
+                    "name": "User",
+                    "your_email": "user@example.com",
+                    "message": "Hello",
+                },
+            )
             self.assertStatus(response, 200)
             self.assertTrue(response.get_json()["sent"])
 
@@ -419,12 +413,11 @@ class ContactAndEmailCoverageTests(MainViewsCoverageMixin, BaseTestCase):
     def test_contact_ajax_validation_error(self, _recaptcha):
         with current_app.app_context():
             journal = utils.makeOneJournal({"enable_contact": True})
-            with self._without_csrf():
-                response = self.client.post(
-                    url_for("main.contact", url_seg=journal.url_segment),
-                    headers=AJAX_HEADERS,
-                    data={"name": "", "your_email": "bad", "message": ""},
-                )
+            response = self.client.post(
+                url_for("main.contact", url_seg=journal.url_segment),
+                headers=ajax_headers(),
+                data={"name": "", "your_email": "bad", "message": ""},
+            )
             self.assertStatus(response, 200)
             self.assertFalse(response.get_json()["sent"])
 
@@ -434,10 +427,28 @@ class ContactAndEmailCoverageTests(MainViewsCoverageMixin, BaseTestCase):
             journal = utils.makeOneJournal({"enable_contact": True})
             response = self.client.post(
                 url_for("main.contact", url_seg=journal.url_segment),
-                headers=AJAX_HEADERS,
+                headers=ajax_headers(),
                 data={"name": "User", "your_email": "user@example.com", "message": "Hi"},
             )
             self.assertStatus(response, 400)
+
+    @patch("webapp.main.views.utils.is_recaptcha_valid", return_value=True)
+    def test_contact_ajax_invalid_origin(self, _recaptcha):
+        with current_app.app_context():
+            journal = utils.makeOneJournal({"enable_contact": True})
+            response = self.client.post(
+                url_for("main.contact", url_seg=journal.url_segment),
+                headers={
+                    "X-Requested-With": "XMLHttpRequest",
+                    "Origin": "https://evil.example",
+                },
+                data={
+                    "name": "User",
+                    "your_email": "user@example.com",
+                    "message": "Hello",
+                },
+            )
+            self.assertStatus(response, 403)
 
     def test_form_contact_renders_template(self):
         with current_app.app_context():
@@ -447,36 +458,51 @@ class ContactAndEmailCoverageTests(MainViewsCoverageMixin, BaseTestCase):
             )
             self.assertStatus(response, 200)
             self.assertTemplateUsed("journal/includes/contact_form.html")
+            self.assertNotIn(b"csrf_token", response.data)
 
     @patch("webapp.main.views.controllers.send_email_share")
-    def test_email_share_ajax_success(self, mock_send):
+    @patch("webapp.main.views.utils.is_recaptcha_valid", return_value=True)
+    def test_email_share_ajax_success(self, _recaptcha, mock_send):
         mock_send.return_value = (True, "ok")
         with current_app.app_context():
-            with self._without_csrf():
-                response = self.client.post(
-                    url_for("main.email_share_ajax"),
-                    headers=AJAX_HEADERS,
-                    data={
-                        "your_email": "sender@example.com",
-                        "recipients": "one@example.com",
-                        "share_url": "http://example.com/article",
-                        "subject": "Read this",
-                        "comment": "Nice article",
-                    },
-                )
+            response = self.client.post(
+                url_for("main.email_share_ajax"),
+                headers=ajax_headers(),
+                data={
+                    "your_email": "sender@example.com",
+                    "recipients": "one@example.com",
+                    "share_url": "http://example.com/article",
+                    "subject": "Read this",
+                    "comment": "Nice article",
+                },
+            )
             self.assertStatus(response, 200)
             self.assertTrue(response.get_json()["sent"])
 
-    def test_email_share_ajax_validation_error(self):
+    @patch("webapp.main.views.utils.is_recaptcha_valid", return_value=True)
+    def test_email_share_ajax_validation_error(self, _recaptcha):
         with current_app.app_context():
-            with self._without_csrf():
-                response = self.client.post(
-                    url_for("main.email_share_ajax"),
-                    headers=AJAX_HEADERS,
-                    data={"your_email": "bad", "recipients": "bad", "share_url": "not-a-url"},
-                )
+            response = self.client.post(
+                url_for("main.email_share_ajax"),
+                headers=ajax_headers(),
+                data={"your_email": "bad", "recipients": "bad", "share_url": "not-a-url"},
+            )
             self.assertStatus(response, 200)
             self.assertFalse(response.get_json()["sent"])
+
+    @patch("webapp.main.views.utils.is_recaptcha_valid", return_value=False)
+    def test_email_share_ajax_invalid_captcha(self, _recaptcha):
+        with current_app.app_context():
+            response = self.client.post(
+                url_for("main.email_share_ajax"),
+                headers=ajax_headers(),
+                data={
+                    "your_email": "sender@example.com",
+                    "recipients": "one@example.com",
+                    "share_url": "http://example.com/article",
+                },
+            )
+            self.assertStatus(response, 400)
 
     def test_email_form_renders(self):
         with current_app.app_context():
@@ -484,26 +510,44 @@ class ContactAndEmailCoverageTests(MainViewsCoverageMixin, BaseTestCase):
                 url_for("main.email_form"), query_string={"url": "http://example.com"}
             )
             self.assertStatus(response, 200)
+            self.assertNotIn(b"csrf_token", response.data)
 
     @patch("webapp.main.views.controllers.send_email_error")
-    def test_email_error_ajax_success(self, mock_send):
+    @patch("webapp.main.views.utils.is_recaptcha_valid", return_value=True)
+    def test_email_error_ajax_success(self, _recaptcha, mock_send):
         mock_send.return_value = (True, "reported")
         with current_app.app_context():
-            with self._without_csrf():
-                response = self.client.post(
-                    url_for("main.email_error_ajax"),
-                    headers=AJAX_HEADERS,
-                    data={
-                        "name": "User",
-                        "your_email": "user@example.com",
-                        "error_type": "404",
-                        "url": "http://example.com/missing",
-                        "page_title": "Missing",
-                        "message": "Broken link",
-                    },
-                )
+            response = self.client.post(
+                url_for("main.email_error_ajax"),
+                headers=ajax_headers(),
+                data={
+                    "name": "User",
+                    "your_email": "user@example.com",
+                    "error_type": "404",
+                    "url": "http://example.com/missing",
+                    "page_title": "Missing",
+                    "message": "Broken link",
+                },
+            )
             self.assertStatus(response, 200)
             self.assertTrue(response.get_json()["sent"])
+
+    @patch("webapp.main.views.utils.is_recaptcha_valid", return_value=False)
+    def test_email_error_ajax_invalid_captcha(self, _recaptcha):
+        with current_app.app_context():
+            response = self.client.post(
+                url_for("main.email_error_ajax"),
+                headers=ajax_headers(),
+                data={
+                    "name": "User",
+                    "your_email": "user@example.com",
+                    "error_type": "404",
+                    "url": "http://example.com/missing",
+                    "page_title": "Missing",
+                    "message": "Broken link",
+                },
+            )
+            self.assertStatus(response, 400)
 
     def test_error_form_renders(self):
         with current_app.app_context():
@@ -511,6 +555,16 @@ class ContactAndEmailCoverageTests(MainViewsCoverageMixin, BaseTestCase):
                 url_for("main.error_form"), query_string={"url": "http://example.com"}
             )
             self.assertStatus(response, 200)
+            self.assertNotIn(b"csrf_token", response.data)
+
+    def test_public_home_does_not_set_opac_session_cookie(self):
+        with current_app.app_context():
+            utils.makeOneCollection()
+            response = self.client.get("/")
+            self.assertStatus(response, 200)
+            set_cookie = "; ".join(response.headers.getlist("Set-Cookie"))
+            cookie_name = current_app.config.get("SESSION_COOKIE_NAME", "opac_session")
+            self.assertNotIn("%s=" % cookie_name, set_cookie)
 
 
 class IssueTocCoverageTests(MainViewsCoverageMixin, BaseTestCase):
@@ -1034,7 +1088,7 @@ class MiscRoutesCoverageTests(MainViewsCoverageMixin, BaseTestCase):
             response = self.client.get(
                 url_for("main.scimago_ir"),
                 query_string={"q": "university"},
-                headers=AJAX_HEADERS,
+                headers=ajax_headers(),
             )
             self.assertStatus(response, 200)
             self.assertIn("institution.php", response.get_data(as_text=True))
@@ -1046,7 +1100,7 @@ class MiscRoutesCoverageTests(MainViewsCoverageMixin, BaseTestCase):
             response = self.client.get(
                 url_for("main.scimago_ir"),
                 query_string={"q": "missing"},
-                headers=AJAX_HEADERS,
+                headers=ajax_headers(),
             )
             self.assertStatus(response, 200)
             self.assertEqual(response.get_data(as_text=True), "")
@@ -1247,34 +1301,21 @@ class RemainingMainViewsCoverageTests(MainViewsCoverageMixin, BaseTestCase):
             journal = utils.makeOneJournal({"enable_contact": False})
             response = self.client.post(url_for("main.contact", url_seg=journal.url_segment))
             self.assertStatus(response, 403)
-            with self._without_csrf():
-                response = self.client.post(
-                    url_for("main.contact", url_seg=journal.url_segment),
-                    headers=AJAX_HEADERS,
-                    data={
-                        "name": "User",
-                        "your_email": "user@example.com",
-                        "message": "Hi",
-                    },
-                )
+            response = self.client.post(
+                url_for("main.contact", url_seg=journal.url_segment),
+                headers=ajax_headers(),
+                data={
+                    "name": "User",
+                    "your_email": "user@example.com",
+                    "message": "Hi",
+                },
+            )
             self.assertStatus(response, 403)
 
     def test_form_contact_journal_not_found(self):
         with current_app.app_context():
             response = self.client.get(url_for("main.form_contact", url_seg="missing"))
             self.assertStatus(response, 404)
-
-    @contextmanager
-    def _without_csrf(self):
-        previous = current_app.config.get("WTF_CSRF_ENABLED")
-        current_app.config["WTF_CSRF_ENABLED"] = False
-        try:
-            yield
-        finally:
-            if previous is None:
-                current_app.config.pop("WTF_CSRF_ENABLED", None)
-            else:
-                current_app.config["WTF_CSRF_ENABLED"] = previous
 
     def test_issue_toc_get_without_section_filter(self):
         with current_app.app_context():
@@ -1571,18 +1612,18 @@ class RemainingMainViewsCoverageTests(MainViewsCoverageMixin, BaseTestCase):
                 current_app.config["COMMON_STYLE_LIST"] = previous
                 os.unlink(csl_file.name)
 
-    def test_email_endpoints_require_xhr_and_validation_error(self):
+    @patch("webapp.main.views.utils.is_recaptcha_valid", return_value=True)
+    def test_email_endpoints_require_xhr_and_validation_error(self, _recaptcha):
         with current_app.app_context():
             response = self.client.post(url_for("main.email_share_ajax"))
             self.assertStatus(response, 400)
             response = self.client.post(url_for("main.email_error_ajax"))
             self.assertStatus(response, 400)
-            with self._without_csrf():
-                response = self.client.post(
-                    url_for("main.email_error_ajax"),
-                    headers=AJAX_HEADERS,
-                    data={"name": "", "your_email": "bad"},
-                )
+            response = self.client.post(
+                url_for("main.email_error_ajax"),
+                headers=ajax_headers(),
+                data={"name": "", "your_email": "bad"},
+            )
             self.assertStatus(response, 200)
             self.assertFalse(response.get_json()["sent"])
 
@@ -1707,7 +1748,7 @@ class FinalMainViewsCoverageTests(MainViewsCoverageMixin, BaseTestCase):
             response = self.client.get(
                 url_for("main.journals_search_by_theme_ajax"),
                 query_string={"filter": "areas"},
-                headers=AJAX_HEADERS,
+                headers=ajax_headers(),
             )
             self.assertStatus(response, 200)
 

--- a/opac/tests/test_utils_coverage.py
+++ b/opac/tests/test_utils_coverage.py
@@ -444,6 +444,50 @@ class UtilsCoverageTestCase(BaseTestCase):
         self.assertTrue(is_recaptcha_valid(request))
         mocked_post.assert_called_once()
 
+    def test_is_same_origin_request_with_origin(self):
+        from webapp.utils.utils import is_same_origin_request
+
+        with current_app.test_request_context(
+            "/",
+            headers={"Origin": "http://localhost"},
+            base_url="http://localhost/",
+        ):
+            from flask import request
+
+            self.assertTrue(is_same_origin_request(request))
+
+    def test_is_same_origin_request_with_referer(self):
+        from webapp.utils.utils import is_same_origin_request
+
+        with current_app.test_request_context(
+            "/",
+            headers={"Referer": "http://localhost/j/foo"},
+            base_url="http://localhost/",
+        ):
+            from flask import request
+
+            self.assertTrue(is_same_origin_request(request))
+
+    def test_is_same_origin_request_rejects_foreign_origin(self):
+        from webapp.utils.utils import is_same_origin_request
+
+        with current_app.test_request_context(
+            "/",
+            headers={"Origin": "https://evil.example"},
+            base_url="http://localhost/",
+        ):
+            from flask import request
+
+            self.assertFalse(is_same_origin_request(request))
+
+    def test_is_same_origin_request_rejects_missing_headers(self):
+        from webapp.utils.utils import is_same_origin_request
+
+        with current_app.test_request_context("/", base_url="http://localhost/"):
+            from flask import request
+
+            self.assertFalse(is_same_origin_request(request))
+
     def test_asbool_all_branches(self):
         self.assertFalse(asbool(None))
         self.assertTrue(asbool(True))

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -126,7 +126,7 @@ import ast
         - OPAC_SESSION_COOKIE_DOMAIN: o dominio para a cookie da sessão (default: OPAC_SERVER_NAME)
         - OPAC_SESSION_COOKIE_HTTPONLY: Seta a flag: httponly da cookie. (defaults to True)
         - OPAC_SESSION_COOKIE_NAME: nome da cookie de sessão (default: 'opac_session')
-        - OPAC_SESSION_COOKIE_PATH: path para a cookie de sessão: (default: None -> ou seja a raiz /)
+        - OPAC_SESSION_COOKIE_PATH: path para a cookie de sessão: (default: '/admin')
         - OPAC_SESSION_COOKIE_SECURE: define se a cookie de sessão deve ser marcada como segura - (default: False)
         - OPAC_SESSION_REFRESH_EACH_REQUEST: Fazer refresh da cookie em cada request? (Default: 'False')
 
@@ -524,7 +524,7 @@ SESSION_COOKIE_HTTPONLY = (
     os.environ.get("OPAC_SESSION_COOKIE_HTTPONLY", "True") == "True"
 )
 SESSION_COOKIE_NAME = os.environ.get("OPAC_SESSION_COOKIE_NAME", "opac_session")
-SESSION_COOKIE_PATH = os.environ.get("OPAC_SESSION_COOKIE_PATH", None)
+SESSION_COOKIE_PATH = os.environ.get("OPAC_SESSION_COOKIE_PATH", "/admin")
 SESSION_COOKIE_SECURE = os.environ.get("OPAC_SESSION_COOKIE_SECURE", "False") == "True"
 SESSION_REFRESH_EACH_REQUEST = (
     os.environ.get("OPAC_SESSION_REFRESH_EACH_REQUEST", "False") == "True"

--- a/opac/webapp/forms.py
+++ b/opac/webapp/forms.py
@@ -9,6 +9,9 @@ from wtforms.validators import URL, DataRequired, Email, ValidationError
 
 
 class EmailShareForm(FlaskForm):
+    class Meta:
+        csrf = False
+
     your_email = StringField("your_email", validators=[DataRequired(), Email()])
     recipients = StringField("recipients", validators=[DataRequired()])
     share_url = HiddenField("share_url", validators=[URL(), DataRequired()])
@@ -31,12 +34,18 @@ class EmailShareForm(FlaskForm):
 
 
 class ContactForm(FlaskForm):
+    class Meta:
+        csrf = False
+
     name = StringField("name", validators=[DataRequired()])
     your_email = StringField("your_email", validators=[DataRequired(), Email()])
     message = TextAreaField("message", validators=[DataRequired()])
 
 
 class ErrorForm(FlaskForm):
+    class Meta:
+        csrf = False
+
     name = StringField("name", validators=[DataRequired()])
     your_email = StringField("your_email", validators=[DataRequired(), Email()])
     error_type = StringField("error_type", validators=[DataRequired()])

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -121,13 +121,6 @@ def clear_legacy_language_cookie(response):
 
 
 @main.before_app_request
-def add_forms_to_g():
-    setattr(g, "email_share", forms.EmailShareForm())
-    setattr(g, "email_contact", forms.ContactForm())
-    setattr(g, "error", forms.ErrorForm())
-
-
-@main.before_app_request
 def add_scielo_org_config_to_g():
     language = get_locale()
     scielo_org_links = {
@@ -768,6 +761,9 @@ def contact(url_seg):
     if not request.headers.get("X-Requested-With"):
         abort(403, _("Requisição inválida, deve ser ajax."))
 
+    if not utils.is_same_origin_request(request):
+        abort(403, _("Requisição inválida, origem não permitida."))
+
     if utils.is_recaptcha_valid(request):
         form = forms.ContactForm(request.form)
 
@@ -813,7 +809,7 @@ def form_contact(url_seg):
     if not journal:
         abort(404, _("Periódico não encontrado"))
 
-    context = {"journal": journal}
+    context = {"journal": journal, "form": forms.ContactForm()}
     return render_template("journal/includes/contact_form.html", **context)
 
 
@@ -1707,6 +1703,12 @@ def email_share_ajax():
     if not request.headers.get("X-Requested-With"):
         abort(400, _("Requisição inválida."))
 
+    if not utils.is_same_origin_request(request):
+        abort(403, _("Requisição inválida, origem não permitida."))
+
+    if not utils.is_recaptcha_valid(request):
+        abort(400, _("Requisição inválida, captcha inválido."))
+
     form = forms.EmailShareForm(request.form)
 
     if form.validate():
@@ -1744,7 +1746,7 @@ def email_share_ajax():
 
 @main.route("/form_mail/", methods=["GET"])
 def email_form():
-    context = {"url": request.args.get("url")}
+    context = {"url": request.args.get("url"), "form": forms.EmailShareForm()}
     return render_template("email/email_form.html", **context)
 
 
@@ -1752,6 +1754,12 @@ def email_form():
 def email_error_ajax():
     if not request.headers.get("X-Requested-With"):
         abort(400, _("Requisição inválida."))
+
+    if not utils.is_same_origin_request(request):
+        abort(403, _("Requisição inválida, origem não permitida."))
+
+    if not utils.is_recaptcha_valid(request):
+        abort(400, _("Requisição inválida, captcha inválido."))
 
     form = forms.ErrorForm(request.form)
 
@@ -1792,7 +1800,7 @@ def email_error_ajax():
 
 @main.route("/error_mail/", methods=["GET"])
 def error_form():
-    context = {"url": request.args.get("url")}
+    context = {"url": request.args.get("url"), "form": forms.ErrorForm()}
     return render_template("includes/error_form.html", **context)
 
 

--- a/opac/webapp/templates/email/email_form.html
+++ b/opac/webapp/templates/email/email_form.html
@@ -6,19 +6,18 @@
       <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
     </div>
     <form name="share_form_id" id="share_form_id" class="validate">
-      {{ g.email_share.csrf_token() }}
-      {{ g.email_share.share_url(value=url) }}
+      {{ form.share_url(value=url) }}
       <div class="modal-body">
         
         <div class="form-group">
           <label class="control-label">{% trans %}Seu e-mail{% endtrans %}*</label>
-            {{ g.email_share.your_email(class="form-control valid") }}
-            <label class="control-label" id="{{g.email_share.your_email.name}}_error"></label>
+            {{ form.your_email(class="form-control valid") }}
+            <label class="control-label" id="{{form.your_email.name}}_error"></label>
         </div>
         <div class="form-group">
           <label class="control-label">{% trans %}Para{% endtrans %}*</label>
-          {{ g.email_share.recipients(class="form-control valid multipleMail") }}
-          <label class="control-label" id="{{g.email_share.recipients.name}}_error"></label>
+          {{ form.recipients(class="form-control valid multipleMail") }}
+          <label class="control-label" id="{{form.recipients.name}}_error"></label>
           <span class="text-muted">
             {% trans %}Utilize ; (ponto e vírgula) para inserir mais emails.{% endtrans %}
           </span>
@@ -35,11 +34,11 @@
           <div id="extraFields" style="display: none;">
             <div class="form-group">
               <label>{% trans %}Assunto{% endtrans %}</label>
-              {{ g.email_share.subject(class="form-control valid") }}
+              {{ form.subject(class="form-control valid") }}
             </div>
             <div class="form-group">
               <label>{% trans %}Comentário{% endtrans %}</label>
-              {{ g.email_share.comment(class="form-control") }}
+              {{ form.comment(class="form-control") }}
             </div>
             <a href="javascript:;" class="showBlock" data-rel="#showBlock" data-hide="#extraFields">
               {% trans %}Remover remetente, assunto e comentários{% endtrans %}

--- a/opac/webapp/templates/includes/error_form.html
+++ b/opac/webapp/templates/includes/error_form.html
@@ -8,25 +8,23 @@
 
         <form action="" method="POST" id="error_form_id">
 
-            {{ g.error.csrf_token() }}
+            {{ form.url(value=url) }}
 
-            {{ g.error.url(value=url) }}
-
-            {{ g.error.page_title(value="") }}
+            {{ form.page_title(value="") }}
 
 
             <div class="modal-body">
 
                 <div class="mb-0">
                     <label class="form-label">{% trans %}Seu Nome{% endtrans %} *</label>
-                    {{ g.error.name(class="form-control valid", placeholder=_("Digite seu Nome")) }}
-                    <label class="form-label" id="{{g.error.name.name}}_error"></label>
+                    {{ form.name(class="form-control valid", placeholder=_("Digite seu Nome")) }}
+                    <label class="form-label" id="{{form.name.name}}_error"></label>
                 </div>
 
                 <div class="mb-0">
                   <label class="form-label">{% trans %}Seu e-mail{% endtrans %} *</label>
-                    {{ g.error.your_email(class="form-control valid", placeholder=_("Digite seu e-mail")) }}
-                  <label class="form-label" id="{{g.error.your_email.name}}_error"></label>
+                    {{ form.your_email(class="form-control valid", placeholder=_("Digite seu e-mail")) }}
+                  <label class="form-label" id="{{form.your_email.name}}_error"></label>
                 </div>
 
                 <div class="mb-0">
@@ -42,13 +40,13 @@
                         <label class="form-check-label" for="error_type2">{% trans %}outro tipo de erro{% endtrans %} *</label>
                         <span class="form-text d-block">* {% trans %}Caso o erro esteja no conteúdo de um documento e apresente-se também na versão em PDF do mesmo documento, por favor não utilize este formulário. Entre em contato com o periódico que publicou o documento e reporte o erro diretamente a ele.{% endtrans %}</span>
                     </div>
-                    <label class="form-label" id="{{g.error.error_type.name}}_error"></label>
+                    <label class="form-label" id="{{form.error_type.name}}_error"></label>
                 </div>
 
                 <div class="mb-3">
                     <label class="form-label">{% trans %}Descrição do erro{% endtrans %}:</label>
-                    {{ g.error.message(class="form-control valid", placeholder=_("Digite sua mensagem"), rows="10") }}
-                    <label class="form-label" id="{{g.error.message.name}}_error"></label>
+                    {{ form.message(class="form-control valid", placeholder=_("Digite sua mensagem"), rows="10") }}
+                    <label class="form-label" id="{{form.message.name}}_error"></label>
                     <span class="form-text">{% trans %}Obs.: Link e título da página são enviados automaticamente{% endtrans %}.</span>
                 </div>
 

--- a/opac/webapp/templates/journal/includes/contact_form.html
+++ b/opac/webapp/templates/journal/includes/contact_form.html
@@ -6,26 +6,24 @@
     </div>
     <form name="contact_form_id" id="contact_form_id" class="validate">
 
-      {{ g.email_contact.csrf_token() }}
-
       <div class="modal-body">
 
         <div class="form-group">
           <label class="control-label">{% trans %}Seu Nome{% endtrans %}*</label>
-            {{ g.email_contact.name(class="form-control valid", placeholder="Digite seu Nome") }}
-            <label class="control-label" id="{{g.email_contact.name.name}}_error"></label>
+            {{ form.name(class="form-control valid", placeholder="Digite seu Nome") }}
+            <label class="control-label" id="{{form.name.name}}_error"></label>
         </div>
 
         <div class="form-group">
           <label class="control-label">{% trans %}Seu e-mail{% endtrans %}*</label>
-            {{ g.email_contact.your_email(class="form-control valid", placeholder="Digite seu e-mail") }}
-            <label class="control-label" id="{{g.email_contact.your_email.name}}_error"></label>
+            {{ form.your_email(class="form-control valid", placeholder="Digite seu e-mail") }}
+            <label class="control-label" id="{{form.your_email.name}}_error"></label>
         </div>
 
         <div class="form-group">
           <label class="control-label">{% trans %}Mensagem{% endtrans %}*</label>
-            {{ g.email_contact.message(class="form-control valid", placeholder="Digite sua mensagem", rows="10") }}
-            <label class="control-label" id="{{g.email_contact.message.name}}_error"></label>
+            {{ form.message(class="form-control valid", placeholder="Digite sua mensagem", rows="10") }}
+            <label class="control-label" id="{{form.message.name}}_error"></label>
         </div>
 
         <div class="form-group">

--- a/opac/webapp/utils/utils.py
+++ b/opac/webapp/utils/utils.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 from datetime import datetime, timedelta
+from urllib.parse import urlparse
 from uuid import uuid4
 
 import pytz
@@ -491,6 +492,28 @@ def utc_to_local(utc_dt):
     local_dt = utc_dt.replace(tzinfo=pytz.utc).astimezone(local_tz)
 
     return local_tz.normalize(local_dt)
+
+
+def is_same_origin_request(request):
+    """
+    Fail-closed same-origin check for anonymous AJAX form POSTs.
+
+    Prefers the Origin header; falls back to the Referer netloc. Requests
+    without either header are rejected.
+    """
+    expected = urlparse(request.host_url).netloc.lower()
+    if not expected:
+        return False
+
+    origin = request.headers.get("Origin")
+    if origin:
+        return urlparse(origin).netloc.lower() == expected
+
+    referer = request.headers.get("Referer")
+    if referer:
+        return urlparse(referer).netloc.lower() == expected
+
+    return False
 
 
 def is_recaptcha_valid(request):


### PR DESCRIPTION
## O que esse PR faz?

Remove a emissão do cookie de sessão Flask `opac_session` nas páginas públicas, para permitir cache eficiente no BunnyCDN.

- Desativa CSRF nos forms anônimos (contato, share por e-mail, reportar erro)
- Remove `add_forms_to_g` (não instancia `FlaskForm` em todo request)
- Protege os POSTs com checagem de Origin/Referer + reCAPTCHA (share/erro passam a validar captcha no backend)
- Define `SESSION_COOKIE_PATH=/admin` para o cookie de sessão ficar restrito ao admin (Flask-Login)

## Onde a revisão poderia começar?

1. [`opac/webapp/forms.py`](opac/webapp/forms.py) — `Meta.csrf = False`
2. [`opac/webapp/main/views.py`](opac/webapp/main/views.py) — remoção de `add_forms_to_g`; POSTs `contact` / `email_share_ajax` / `email_error_ajax`
3. [`opac/webapp/utils/utils.py`](opac/webapp/utils/utils.py) — `is_same_origin_request`
4. [`opac/webapp/config/default.py`](opac/webapp/config/default.py) — `SESSION_COOKIE_PATH`

## Como este poderia ser testado manualmente?

1. Abrir a home (ou qualquer página pública) em aba anônima e inspecionar cookies: **não** deve surgir `opac_session` no path `/`.
2. Abrir o modal **Enviar página por e-mail** e **Reportar erro**: preencher, resolver reCAPTCHA e enviar com sucesso.
3. Tentar POST dos endpoints AJAX sem Origin/Referer válido ou com captcha inválido → deve falhar (400/403).
4. Fazer login em `/admin/`: deve autenticar; o cookie `opac_session` deve ter `Path=/admin`.
5. (Opcional) Confirmar com a infra bypass de cache BunnyCDN em `/admin*`.

Testes unitários relevantes:

```bash
export OPAC_CONFIG="config/templates/testing.template"
flask --app opac.app test -p "test_main_views_coverage.ContactAndEmailCoverageTests"
flask --app opac.app test -p "test_glue_coverage.FormsGlueCoverageTestCase"
flask --app opac.app test -p "test_admin_views.AdminViewsTestCase.test_login_successfully"