### PR TITLE
Propagate ilang on internal navigation links

### DIFF
--- a/opac/tests/test_interface_header.py
+++ b/opac/tests/test_interface_header.py
@@ -1,9 +1,23 @@
 # coding: utf-8
 
-from flask import current_app, g, url_for
+import re
+
+from flask import current_app, g
 
 from . import utils
 from .base import BaseTestCase
+
+
+def _switcher_dropdown_html(html):
+    """Extract the language switcher dropdown menu markup."""
+    match = re.search(
+        r'<ul class="dropdown-menu dropdown-menu-end">(.*?)</ul>',
+        html,
+        re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError("Language switcher dropdown not found in HTML")
+    return match.group(1)
 
 
 class HeaderTestCase(BaseTestCase):
@@ -21,10 +35,13 @@ class HeaderTestCase(BaseTestCase):
                 self.assertTemplateUsed("collection/index.html")
                 self.assertEqual(g.lang, "pt_BR")
                 html = response.data.decode("utf-8").replace("&amp;", "&")
-                self.assertIn("ilang=en", html)
-                self.assertIn("ilang=es", html)
+                switcher = _switcher_dropdown_html(html)
+                self.assertIn('href="/?ilang=en"', switcher)
+                self.assertIn('href="/?ilang=es"', switcher)
                 # Current language is shown as label, not as a switcher link.
-                self.assertNotIn('href="/?ilang=pt_BR"', html)
+                self.assertNotIn('href="/?ilang=pt_BR"', switcher)
+                # Nav/home links still keep the current interface language.
+                self.assertIn('href="/?ilang=pt_BR"', html)
 
     def test_current_language_when_set_en(self):
         """
@@ -40,9 +57,11 @@ class HeaderTestCase(BaseTestCase):
                 self.assertTemplateUsed("collection/index.html")
                 self.assertEqual(g.lang, "en")
                 html = response.data.decode("utf-8").replace("&amp;", "&")
-                self.assertIn("ilang=pt_BR", html)
-                self.assertIn("ilang=es", html)
-                self.assertNotIn('href="/?ilang=en"', html)
+                switcher = _switcher_dropdown_html(html)
+                self.assertIn('href="/?ilang=pt_BR"', switcher)
+                self.assertIn('href="/?ilang=es"', switcher)
+                self.assertNotIn('href="/?ilang=en"', switcher)
+                self.assertIn('href="/?ilang=en"', html)
 
     def test_current_language_when_set_es(self):
         """
@@ -58,6 +77,8 @@ class HeaderTestCase(BaseTestCase):
                 self.assertTemplateUsed("collection/index.html")
                 self.assertEqual(g.lang, "es")
                 html = response.data.decode("utf-8").replace("&amp;", "&")
-                self.assertIn("ilang=pt_BR", html)
-                self.assertIn("ilang=en", html)
-                self.assertNotIn('href="/?ilang=es"', html)
+                switcher = _switcher_dropdown_html(html)
+                self.assertIn('href="/?ilang=pt_BR"', switcher)
+                self.assertIn('href="/?ilang=en"', switcher)
+                self.assertNotIn('href="/?ilang=es"', switcher)
+                self.assertIn('href="/?ilang=es"', html)

--- a/opac/tests/test_interface_locale.py
+++ b/opac/tests/test_interface_locale.py
@@ -202,6 +202,45 @@ class InterfaceLocaleTestCase(BaseTestCase):
         with current_app.test_request_context("/journals/?q=1"):
             self.assertEqual(url_for_ilang("es"), "/journals/?q=1&ilang=es")
 
+    def test_nav_links_preserve_ilang(self):
+        with self.client as client:
+            response = client.get("/?ilang=en")
+            self.assertStatus(response, 200)
+            html = response.data.decode("utf-8").replace("&amp;", "&")
+            self.assertIn("ilang=en", html)
+            # Lista alfabética: status e ilang na mesma query (um único ?)
+            self.assertRegex(
+                html,
+                r'href="[^"]*journals/alpha\?[^"]*status=current[^"]*ilang=en[^"]*"'
+                r'|href="[^"]*journals/alpha\?[^"]*ilang=en[^"]*status=current[^"]*"',
+            )
+            self.assertNotRegex(
+                html,
+                r'href="[^"]*journals/alpha[^"]*\?[^"]*\?',
+            )
+
+    def test_collection_list_links_preserve_ilang(self):
+        with self.client as client:
+            response = client.get("/journals/alpha?ilang=es&status=current")
+            self.assertStatus(response, 200)
+            html = response.data.decode("utf-8").replace("&amp;", "&")
+            self.assertRegex(
+                html,
+                r'href="[^"]*journals/thematic\?[^"]*status=current[^"]*ilang=es[^"]*"'
+                r'|href="[^"]*journals/thematic\?[^"]*ilang=es[^"]*status=current[^"]*"',
+            )
+            # Home logo / index also carries ilang
+            self.assertIn("ilang=es", html)
+            self.assertRegex(html, r'href="/\?ilang=es"|href="[^"]*/\?ilang=es"')
+
+    def test_switcher_still_changes_ilang_independently(self):
+        with self.client as client:
+            response = client.get("/?ilang=en")
+            self.assertStatus(response, 200)
+            html = response.data.decode("utf-8").replace("&amp;", "&")
+            self.assertIn("/?ilang=es", html)
+            self.assertIn("/?ilang=pt_BR", html)
+
     def test_does_not_clear_language_cookie_when_absent(self):
         with self.client as client:
             response = client.get("/")

--- a/opac/tests/test_interface_menu.py
+++ b/opac/tests/test_interface_menu.py
@@ -51,20 +51,21 @@ class MenuTestCase(BaseTestCase):
                     follow_redirects=True,
                 )
                 response = c.get(url_for("main.index"))
-                response_data = response.data.decode("utf-8")
+                response_data = response.data.decode("utf-8").replace("&amp;", "&")
                 self.assertStatus(response, 200)
-                self.assertIn(url_for("main.index"), response_data)
+                self.assertIn("ilang=pt_BR", response_data)
                 self.assertIn(
                     collection.name or __("NOME DA COLEÇÃO!!"),
                     response_data,
                 )
                 self.assertIn(
-                    url_for(".collection_list") + "?status=current",
+                    "/journals/alpha?status=current",
                     response_data,
                 )
+                self.assertIn("ilang=pt_BR", response_data)
                 self.assertIn(str(__("Lista alfabética de periódicos")), response_data)
                 self.assertIn(
-                    url_for(".collection_list_thematic") + "?status=current",
+                    "/journals/thematic?status=current",
                     response_data,
                 )
                 self.assertIn(str(__("Lista temática de periódicos")), response_data)
@@ -82,9 +83,9 @@ class MenuTestCase(BaseTestCase):
                     response_data,
                 )
                 self.assertIn(str(__("Métricas")), response_data)
-                self.assertIn(url_for(".about_collection"), response_data)
+                self.assertIn("/about/?ilang=pt_BR", response_data)
                 self.assertIn(str(__("Sobre o")), response_data)
-                self.assertIn(url_for(".about_collection") + "#contact", response_data)
+                self.assertIn("/about/?ilang=pt_BR#contact", response_data)
                 self.assertIn(str(__("Contatos")), response_data)
                 self.assertIn(current_app.config["URL_SCIELO_ORG"], response_data)
                 self.assertIn(str(__("SciELO.org - Rede SciELO")), response_data)

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -2288,8 +2288,10 @@ class PageTestCase(BaseTestCase):
 
             self.assertEqual(200, response.status_code)
             self.assertTemplateUsed("collection/about.html")
-            self.assertIn("Critérios SciELO", response.data.decode("utf-8"))
-            self.assertIn('"/about/"', response.data.decode("utf-8"))
+            html = response.data.decode("utf-8").replace("&amp;", "&")
+            self.assertIn("Critérios SciELO", html)
+            # Breadcrumb/nav link to about collection keeps interface language.
+            self.assertIn("/about/?ilang=", html)
             self.assertEqual(
                 self.get_context_variable("page").slug_name, page.slug_name
             )

--- a/opac/tests/test_utils_i18n.py
+++ b/opac/tests/test_utils_i18n.py
@@ -1,0 +1,231 @@
+# coding: utf-8
+"""Unit tests for webapp.utils.i18n (100% line+branch coverage)."""
+
+from unittest.mock import patch
+
+from flask import current_app
+from webapp.utils import i18n
+
+from .base import BaseTestCase
+
+
+class CanonicalInterfaceLangTests(BaseTestCase):
+    def test_empty_returns_none(self):
+        with current_app.test_request_context("/"):
+            self.assertIsNone(i18n.canonical_interface_lang(None))
+            self.assertIsNone(i18n.canonical_interface_lang(""))
+
+    def test_exact_key(self):
+        with current_app.test_request_context("/"):
+            self.assertEqual(i18n.canonical_interface_lang("pt_BR"), "pt_BR")
+            self.assertEqual(i18n.canonical_interface_lang("en"), "en")
+
+    def test_hyphen_normalized_to_key(self):
+        with current_app.test_request_context("/"):
+            self.assertEqual(i18n.canonical_interface_lang("pt-BR"), "pt_BR")
+
+    def test_case_insensitive_key(self):
+        with current_app.test_request_context("/"):
+            self.assertEqual(i18n.canonical_interface_lang("pt_br"), "pt_BR")
+            self.assertEqual(i18n.canonical_interface_lang("EN"), "en")
+
+    def test_primary_tag_alias(self):
+        with current_app.test_request_context("/"):
+            self.assertEqual(i18n.canonical_interface_lang("en-US"), "en")
+            self.assertEqual(i18n.canonical_interface_lang("es_MX"), "es")
+            self.assertEqual(i18n.canonical_interface_lang("pt"), "pt_BR")
+
+    def test_unknown_code_returns_none(self):
+        with current_app.test_request_context("/"):
+            self.assertIsNone(i18n.canonical_interface_lang("fr"))
+            self.assertIsNone(i18n.canonical_interface_lang("de-DE"))
+
+    def test_empty_languages_config(self):
+        with current_app.test_request_context("/"):
+            previous = current_app.config["LANGUAGES"]
+            current_app.config["LANGUAGES"] = {}
+            try:
+                self.assertIsNone(i18n.canonical_interface_lang("en"))
+            finally:
+                current_app.config["LANGUAGES"] = previous
+
+    def test_primary_alias_not_in_languages(self):
+        with current_app.test_request_context("/"):
+            previous = current_app.config["LANGUAGES"]
+            current_app.config["LANGUAGES"] = {"es": "Español"}
+            try:
+                # primary "en" maps to "en", but "en" is not in LANGUAGES
+                self.assertIsNone(i18n.canonical_interface_lang("en-US"))
+            finally:
+                current_app.config["LANGUAGES"] = previous
+
+    def test_languages_config_none_treated_as_empty(self):
+        with current_app.test_request_context("/"):
+            previous = current_app.config["LANGUAGES"]
+            current_app.config["LANGUAGES"] = None
+            try:
+                self.assertIsNone(i18n.canonical_interface_lang("pt_BR"))
+            finally:
+                current_app.config["LANGUAGES"] = previous
+
+
+class MatchAcceptLanguageTests(BaseTestCase):
+    def test_empty_languages_returns_none(self):
+        with current_app.test_request_context("/"):
+            previous = current_app.config["LANGUAGES"]
+            current_app.config["LANGUAGES"] = {}
+            try:
+                self.assertIsNone(i18n.match_accept_language())
+            finally:
+                current_app.config["LANGUAGES"] = previous
+
+    def test_no_accept_match_returns_none(self):
+        with current_app.test_request_context(
+            "/", headers={"Accept-Language": "fr,de;q=0.8"}
+        ):
+            self.assertIsNone(i18n.match_accept_language())
+
+    def test_match_returns_canonical(self):
+        with current_app.test_request_context(
+            "/", headers={"Accept-Language": "pt-BR,en;q=0.8"}
+        ):
+            self.assertEqual(i18n.match_accept_language(), "pt_BR")
+
+    def test_best_match_unknown_falls_through_to_canonical(self):
+        with current_app.test_request_context("/"):
+            with patch(
+                "webapp.utils.i18n.request.accept_languages"
+            ) as mock_accept:
+                mock_accept.best_match.return_value = "xx-YY"
+                with patch(
+                    "webapp.utils.i18n.canonical_interface_lang", return_value="en"
+                ) as mock_canonical:
+                    result = i18n.match_accept_language()
+                    self.assertEqual(result, "en")
+                    mock_canonical.assert_called_once_with("xx-YY")
+
+    def test_best_match_unknown_and_canonical_none(self):
+        with current_app.test_request_context("/"):
+            with patch(
+                "webapp.utils.i18n.request.accept_languages"
+            ) as mock_accept:
+                mock_accept.best_match.return_value = "zz"
+                with patch(
+                    "webapp.utils.i18n.canonical_interface_lang", return_value=None
+                ):
+                    self.assertIsNone(i18n.match_accept_language())
+
+    def test_best_match_none(self):
+        with current_app.test_request_context("/"):
+            with patch(
+                "webapp.utils.i18n.request.accept_languages"
+            ) as mock_accept:
+                mock_accept.best_match.return_value = None
+                self.assertIsNone(i18n.match_accept_language())
+
+
+class GetLocaleTests(BaseTestCase):
+    def test_ilang_wins(self):
+        with current_app.test_request_context("/?ilang=es"):
+            self.assertEqual(i18n.get_locale(), "es")
+
+    def test_accept_language_when_no_ilang(self):
+        with current_app.test_request_context(
+            "/", headers={"Accept-Language": "en"}
+        ):
+            self.assertEqual(i18n.get_locale(), "en")
+
+    def test_default_when_no_match(self):
+        with current_app.test_request_context(
+            "/", headers={"Accept-Language": "fr"}
+        ):
+            self.assertEqual(
+                i18n.get_locale(), current_app.config.get("BABEL_DEFAULT_LOCALE")
+            )
+
+    def test_default_fallback_when_config_missing_key(self):
+        with current_app.test_request_context(
+            "/", headers={"Accept-Language": "fr"}
+        ):
+            previous = current_app.config.pop("BABEL_DEFAULT_LOCALE", None)
+            try:
+                self.assertEqual(i18n.get_locale(), "pt_BR")
+            finally:
+                if previous is not None:
+                    current_app.config["BABEL_DEFAULT_LOCALE"] = previous
+
+
+class BuildIlangUrlTests(BaseTestCase):
+    def test_replaces_ilang_and_keeps_other_args(self):
+        with current_app.test_request_context("/journals/?foo=1&ilang=pt_BR"):
+            url = i18n.build_ilang_url("en")
+            self.assertTrue(url.startswith("/journals/?"))
+            self.assertIn("foo=1", url)
+            self.assertIn("ilang=en", url)
+
+    def test_adds_ilang_when_query_empty(self):
+        with current_app.test_request_context("/about/"):
+            self.assertEqual(i18n.build_ilang_url("es"), "/about/?ilang=es")
+
+
+class UrlForWithIlangTests(BaseTestCase):
+    def test_injects_ilang_from_g_lang(self):
+        with current_app.test_request_context("/?ilang=es"):
+            from flask import g
+
+            g.lang = "es"
+            url = i18n.url_for_with_ilang("main.index")
+            self.assertIn("ilang=es", url)
+
+    def test_respects_explicit_ilang(self):
+        with current_app.test_request_context("/?ilang=es"):
+            from flask import g
+
+            g.lang = "es"
+            url = i18n.url_for_with_ilang("main.index", ilang="en")
+            self.assertIn("ilang=en", url)
+            self.assertNotIn("ilang=es", url)
+
+    def test_skips_static(self):
+        with current_app.test_request_context("/"):
+            from flask import g
+
+            g.lang = "en"
+            url = i18n.url_for_with_ilang("static", filename="css/bootstrap.css")
+            self.assertNotIn("ilang=", url)
+
+    def test_combines_with_other_query_kwargs(self):
+        with current_app.test_request_context("/"):
+            from flask import g
+
+            g.lang = "en"
+            url = i18n.url_for_with_ilang("main.collection_list", status="current")
+            self.assertIn("status=current", url)
+            self.assertIn("ilang=en", url)
+            self.assertEqual(url.count("?"), 1)
+
+
+class InjectIlangIntoUrlTests(BaseTestCase):
+    def test_none_or_empty_url_returns_none(self):
+        self.assertIsNone(i18n.inject_ilang_into_url(None, "en"))
+        self.assertIsNone(i18n.inject_ilang_into_url("", "en"))
+
+    def test_injects_ilang_preserving_path_and_query(self):
+        result = i18n.inject_ilang_into_url("/about/?x=1", "en")
+        self.assertEqual(result, "/about/?x=1&ilang=en")
+
+    def test_replaces_existing_ilang(self):
+        result = i18n.inject_ilang_into_url("/?ilang=pt_BR", "es")
+        self.assertEqual(result, "/?ilang=es")
+
+    def test_explicit_fragment_overrides(self):
+        result = i18n.inject_ilang_into_url("/about/#old", "en", fragment="new")
+        self.assertEqual(result, "/about/?ilang=en#new")
+
+    def test_keeps_existing_fragment_when_fragment_arg_is_none(self):
+        result = i18n.inject_ilang_into_url("/about/#keep", "en", fragment=None)
+        self.assertEqual(result, "/about/?ilang=en#keep")
+
+    def test_empty_fragment_arg_clears_fragment(self):
+        result = i18n.inject_ilang_into_url("/about/#gone", "en", fragment="")
+        self.assertEqual(result, "/about/?ilang=en")

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -289,22 +289,37 @@ def get_journal_json_data(journal, language="pt"):
         "title": "Interface - Comunica\\u00e7\\u00e3o, Sa\\u00fade, Educa\\u00e7\\u00e3o"
     },
     """
+    # Lazy import avoids circular import during webapp.main.views bootstrap.
+    from webapp.utils.i18n import url_for_with_ilang
+
     issn = next((issn for issn in [journal.scielo_issn, journal.eletronic_issn, journal.print_issn] if issn), "")
     j_data = {
         "id": journal.id,
         "title": journal.title,
         "links": {
-            "detail": url_for("main.journal_detail", url_seg=journal.url_segment),
-            "issue_grid": url_for("main.issue_grid", url_seg=journal.url_segment),
+            "detail": url_for_with_ilang(
+                "main.journal_detail", url_seg=journal.url_segment
+            ),
+            "issue_grid": url_for_with_ilang(
+                "main.issue_grid", url_seg=journal.url_segment
+            ),
             "submission": journal.online_submission_url
-            or url_for("main.about_journal", url_seg=journal.url_segment)
+            or url_for_with_ilang("main.about_journal", url_seg=journal.url_segment)
             + "#submission",
-            "instructions": url_for("main.about_journal", url_seg=journal.url_segment)
+            "instructions": url_for_with_ilang(
+                "main.about_journal", url_seg=journal.url_segment
+            )
             + "#instructions",
-            "about": url_for("main.about_journal", url_seg=journal.url_segment),
-            "contact": url_for("main.about_journal", url_seg=journal.url_segment)
+            "about": url_for_with_ilang(
+                "main.about_journal", url_seg=journal.url_segment
+            ),
+            "contact": url_for_with_ilang(
+                "main.about_journal", url_seg=journal.url_segment
+            )
             + "#contact",
-            "editors": url_for("main.about_journal", url_seg=journal.url_segment)
+            "editors": url_for_with_ilang(
+                "main.about_journal", url_seg=journal.url_segment
+            )
             + "#editors",
             "metrics": f"{current_app.config['METRICS_URL']}?journal={issn}&collection={current_app.config['OPAC_COLLECTION']}" if current_app.config['OPAC_SHOW_METRICS_URL_IN_JOURNAL_LIST'] else None,
         },
@@ -335,7 +350,7 @@ def get_journal_json_data(journal, language="pt"):
         }
 
     if journal.url_next_journal:
-        j_data["url_next_journal"] = url_for(
+        j_data["url_next_journal"] = url_for_with_ilang(
             "main.journal_detail", url_seg=journal.url_next_journal
         )
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -41,6 +41,7 @@ from webapp.utils.i18n import (
     canonical_interface_lang,
     get_locale,
     inject_ilang_into_url,
+    url_for_with_ilang,
 )
 from webapp.main.errors import page_not_found, internal_server_error
 
@@ -94,6 +95,12 @@ def add_langs():
 def url_for_ilang(lang_code):
     """URL da página atual com ``ilang`` na query string."""
     return build_ilang_url(lang_code)
+
+
+@main.app_template_global("url_for")
+def jinja_url_for(endpoint, **values):
+    """Jinja ``url_for`` that keeps interface language via ``ilang``."""
+    return url_for_with_ilang(endpoint, **values)
 
 
 @main.after_request

--- a/opac/webapp/static/js/journal_lists.js
+++ b/opac/webapp/static/js/journal_lists.js
@@ -295,7 +295,8 @@ var JournalCategorizedList = {
 function open_download_url(target_url, query_input_selector) {
   var query = $(query_input_selector).val();
   if ($.trim(query) !== '') {
-    target_url += '?query=' + encodeURIComponent(query)
+    var sep = target_url.indexOf('?') >= 0 ? '&' : '?';
+    target_url += sep + 'query=' + encodeURIComponent(query)
   }
   window.location = target_url;
 }

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -180,6 +180,8 @@
 
   var howcite_initialized = false;
 
+  var citeCslBase = {{ url_for('main.article_cite_csl', article_id=article.id)|tojson }};
+
   $('#ModalHowcite').on('shown.bs.modal', function () {
 
     if (!howcite_initialized) {
@@ -189,7 +191,7 @@
 
       $.each(initial, function (key, value) {
         $.ajax({
-          url: "{{ url_for('main.article_cite_csl', article_id=article.id) }}?style=" + value,
+          url: citeCslBase + (citeCslBase.indexOf('?') >= 0 ? '&' : '?') + 'style=' + value,
           dataType: 'html',
           delay: 250,
           async: true
@@ -231,7 +233,7 @@
       var data = e.params.data;
 
       $.ajax({
-        url: "{{ url_for('main.article_cite_csl', article_id=article.id) }}?style=" + data.id,
+        url: citeCslBase + (citeCslBase.indexOf('?') >= 0 ? '&' : '?') + 'style=' + data.id,
         dataType: 'html',
         delay: 250
       })

--- a/opac/webapp/templates/article/includes/alternative_header.html
+++ b/opac/webapp/templates/article/includes/alternative_header.html
@@ -40,7 +40,7 @@
           <span class="material-icons-outlined scielo-ico-menu-opened">menu_open</span>
           </a>
           <h2 class="logo-svg">
-             <a href="/" title="Ir para a homepage da coleção: {{ coll_macro.get_collection_name() }}"></a>
+             <a href="{{ url_for('.index') }}" title="Ir para a homepage da coleção: {{ coll_macro.get_collection_name() }}"></a>
           </h2>
           <div class="scielo__mainMenu" id="mainMenu">
              <div class="row">
@@ -49,7 +49,7 @@
                    {%- if menu_logo_url -%}
                      {{ cimages.render_logo(menu_logo_url, coll_macro.get_collection_name(), img_class='img-fluid') }}
                    {%- else -%}
-                     <a href="/" aria-label="{% trans %}Página inicial da coleção{% endtrans %} {{ coll_macro.get_collection_name() }}"><div class="scielo__logo-scielo--small" aria-hidden="true"></div></a>
+                     <a href="{{ url_for('.index') }}" aria-label="{% trans %}Página inicial da coleção{% endtrans %} {{ coll_macro.get_collection_name() }}"><div class="scielo__logo-scielo--small" aria-hidden="true"></div></a>
                    {%- endif -%}
                 </div>
              </div>
@@ -62,12 +62,12 @@
                       </a>
                       <ul>
                          <li>
-                            <a href="{{ url_for('.collection_list') }}?status=current" class="tab_link">
+                            <a href="{{ url_for('.collection_list', status='current') }}" class="tab_link">
                             Lista alfabética de periódicos
                             </a>
                          </li>
                          <li>
-                            <a href="{{ url_for('.collection_list_thematic') }}?status=current" class="tab_link">
+                            <a href="{{ url_for('.collection_list_thematic', status='current') }}" class="tab_link">
                             Lista temática de periódicos
                             </a>
                          </li>
@@ -162,7 +162,7 @@
         <a href="" class="menu" data-rel="#alternativeMainMenu" title="{% trans %}Abrir menu{% endtrans %}">{% trans %}Abrir menu{% endtrans %}</a>
         -->
         
-        <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
+        <a href="{{ url_for('.index') }}" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
           <div class="scielo__logo-scielo-collection mt-1">
             <small>{{ coll_macro.get_collection_name() }}</small>
           </div>

--- a/opac/webapp/templates/article/includes/header.html
+++ b/opac/webapp/templates/article/includes/header.html
@@ -46,7 +46,7 @@
                 {%- set header_logo_url = cimages.get_header_logo(g.collection, g.lang)|default('')|trim -%}
                 {%- if header_logo_url -%}
                     <a
-                        href="/"
+                        href="{{ url_for('.index') }}"
                         title="{% trans %}Ir para a homepage da coleção:{% endtrans %} {{ coll_macro.get_collection_name() }}"
                         aria-label="{% trans %}Ir para a homepage da coleção:{% endtrans %} {{ coll_macro.get_collection_name() }}"
                     >
@@ -58,7 +58,7 @@
                     </a>
                 {%- else -%}
                     <a
-                        href="/"
+                        href="{{ url_for('.index') }}"
                         title="{% trans %}Ir para a homepage da coleção:{% endtrans %} {{ coll_macro.get_collection_name() }}"
                         aria-label="{% trans %}Ir para a homepage da coleção:{% endtrans %} {{ coll_macro.get_collection_name() }}"
                     >

--- a/opac/webapp/templates/article/includes/modal/how_cite.html
+++ b/opac/webapp/templates/article/includes/modal/how_cite.html
@@ -47,7 +47,7 @@
           <div class="row">
             <div class="col-sm-3" style="text-align: center;">
               <a
-                href="{{ url_for('main.article_cite_export_format', article_id=article.id) }}?format=ris"
+                href="{{ url_for('main.article_cite_export_format', article_id=article.id, format='ris') }}"
                 class="btn hidden-sm">
                 <span class="glyphicon glyphicon-download" aria-hidden="true"></span>
                 <span class="visually-hidden">{% trans %}Baixar em{% endtrans %}</span> RIS
@@ -56,7 +56,7 @@
 
             <div class="col-sm-3" style="text-align: center;">
               <a
-                href="{{ url_for('main.article_cite_export_format', article_id=article.id) }}?format=bib">
+                href="{{ url_for('main.article_cite_export_format', article_id=article.id, format='bib') }}">
                 <span class="glyphicon glyphicon-download" aria-hidden="true"></span>
                 <span class="visually-hidden">{% trans %}Baixar em{% endtrans %}</span> BIBTEX
               </a>

--- a/opac/webapp/templates/collection/includes/header.html
+++ b/opac/webapp/templates/collection/includes/header.html
@@ -95,7 +95,7 @@
           {%- if logo_url -%}
             {{ img_macro.render_logo(logo_url, coll_macro.get_collection_name()) }}
           {%- else -%}
-            <a href="/">
+            <a href="{{ url_for('.index') }}">
               <h2 class="scielo__logo-scielo-caption mt-1">
                 <small id="collectionNameHome">{{ coll_macro.get_collection_name() }}</small>
               </h2>

--- a/opac/webapp/templates/collection/includes/nav.html
+++ b/opac/webapp/templates/collection/includes/nav.html
@@ -30,7 +30,7 @@
         {%- if menu_logo_url -%}
           {{ img_macro.render_logo(menu_logo_url, coll_macro.get_collection_name(), img_class='img-fluid') }}
         {%- else -%}
-          <a href="/" title="{% trans %}Ir para a página inicial da coleção:{% endtrans %} {{ coll_macro.get_collection_name() }}" aria-label="{% trans %}Página inicial da coleção{% endtrans %} {{ coll_macro.get_collection_name() }}"
+          <a href="{{ url_for('.index') }}" title="{% trans %}Ir para a página inicial da coleção:{% endtrans %} {{ coll_macro.get_collection_name() }}" aria-label="{% trans %}Página inicial da coleção{% endtrans %} {{ coll_macro.get_collection_name() }}"
           ><div class="scielo__logo-scielo--small" aria-hidden="true"></div></a>
         {%- endif -%}
       </li>
@@ -42,12 +42,12 @@
         </a>
         <ul>
           <li>
-            <a href="{{ url_for('.collection_list') }}?status=current" class="tab_link">
+            <a href="{{ url_for('.collection_list', status='current') }}" class="tab_link">
               {% trans %}Lista alfabética de periódicos{% endtrans %}
             </a>
           </li>
           <li>
-            <a href="{{ url_for('.collection_list_thematic') }}?status=current" class="tab_link">
+            <a href="{{ url_for('.collection_list_thematic', status='current') }}" class="tab_link">
               {% trans %}Lista temática de periódicos{% endtrans %}
             </a>
           </li>

--- a/opac/webapp/templates/collection/index.html
+++ b/opac/webapp/templates/collection/index.html
@@ -70,10 +70,10 @@
             <div class="container">
                <div class="row align-items-center">
                   <div class="col-6 col-sm-3 col-md-2">
-                     <a href="{{ url_for('.collection_list') }}?status=current">{% trans %}Alfabética{% endtrans %}</a>
+                     <a href="{{ url_for('.collection_list', status='current') }}">{% trans %}Alfabética{% endtrans %}</a>
                   </div>
                   <div class="col-6 col-sm-3 col-md-2">
-                     <a href="{{ url_for('.collection_list_thematic') }}?status=current">{% trans %}Temática{% endtrans %}</a>
+                     <a href="{{ url_for('.collection_list_thematic', status='current') }}">{% trans %}Temática{% endtrans %}</a>
                   </div>
                   <div class="col">
                      <!-- Form search periódicos -->

--- a/opac/webapp/templates/collection/list_journal.html
+++ b/opac/webapp/templates/collection/list_journal.html
@@ -15,10 +15,10 @@
 
       <ul class="nav nav-tabs">
         <li class="nav-item">
-          <a class="nav-link active alpha-tab" href="{{ url_for('.collection_list') }}?status=current">{% trans %}Alfabética{% endtrans %}</a>
+          <a class="nav-link active alpha-tab" href="{{ url_for('.collection_list', status='current') }}">{% trans %}Alfabética{% endtrans %}</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link thematic-tab" href="{{ url_for('.collection_list_thematic') }}?status=current">{% trans %}Temática{% endtrans %}</a>
+          <a class="nav-link thematic-tab" href="{{ url_for('.collection_list_thematic', status='current') }}">{% trans %}Temática{% endtrans %}</a>
         </li>
       </ul>
       
@@ -37,13 +37,13 @@
                         </a> 
                       </li>
                       <li class="nav-item" role="presentation">
-                        <a class="ms-1 btn btn-sm btn-secondary {% if query_filter == 'current' %}active {% endif %} scielo__btn-with-icon--left" href="{{ url_for('.collection_list') }}?status=current">
+                        <a class="ms-1 btn btn-sm btn-secondary {% if query_filter == 'current' %}active {% endif %} scielo__btn-with-icon--left" href="{{ url_for('.collection_list', status='current') }}">
                           <span class="lbl-corrente">
                             <span class="material-icons" style="color:#1e7c32">fiber_manual_record</span> {% trans %}Ativos{% endtrans %}</span>
                         </a> 
                       </li>
                       <li class="nav-item" role="presentation">
-                        <a class="ms-1 btn btn-sm btn-secondary {% if query_filter == 'no-current' %}active {% endif %} scielo__btn-with-icon--left" href="{{ url_for('.collection_list') }}?status=no-current">
+                        <a class="ms-1 btn btn-sm btn-secondary {% if query_filter == 'no-current' %}active {% endif %} scielo__btn-with-icon--left" href="{{ url_for('.collection_list', status='no-current') }}">
                           <span class="lbl-nao-corrente"><span class="material-icons" style="color: #c63800;">fiber_manual_record</span> {% trans %}Descontinuados{% endtrans %}</span>
                         </a> 
                       </li>
@@ -145,7 +145,7 @@
 
     $('.thematic-tab').click(function(event) {
 
-      window.location.href = "{{ url_for('.collection_list_thematic') }}?status=current";
+      window.location.href = "{{ url_for('.collection_list_thematic', status='current') }}";
 
     });
 

--- a/opac/webapp/templates/collection/list_thematic.html
+++ b/opac/webapp/templates/collection/list_thematic.html
@@ -16,10 +16,10 @@
         <ul class="nav nav-tabs">
             
             <li class="nav-item">
-                <a class="nav-link alpha-tab" href="{{ url_for('.collection_list') }}?status=current">{% trans %}Alfabética{% endtrans %}</a>
+                <a class="nav-link alpha-tab" href="{{ url_for('.collection_list', status='current') }}">{% trans %}Alfabética{% endtrans %}</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link active thematic-tab" href="{{ url_for('.collection_list_thematic') }}?status=current">{% trans %}Temática{% endtrans %}</a>
+                <a class="nav-link active thematic-tab" href="{{ url_for('.collection_list_thematic', status='current') }}">{% trans %}Temática{% endtrans %}</a>
             </li>
         </ul>
 
@@ -46,12 +46,12 @@
                                 </a> 
                             </li>
                             <li class="nav-item" role="presentation">
-                                <a class="ms-1 btn btn-sm btn-secondary {% if query_filter == 'current' %}active {% endif %} scielo__btn-with-icon--left" href="{{ url_for('.collection_list_thematic') }}?status=current">
+                                <a class="ms-1 btn btn-sm btn-secondary {% if query_filter == 'current' %}active {% endif %} scielo__btn-with-icon--left" href="{{ url_for('.collection_list_thematic', status='current') }}">
                                 <span class="lbl-corrente"><span class="material-icons" style="color: #1e7c32">fiber_manual_record</span>{% trans %}Ativos{% endtrans %}</span>
                                 </a> 
                             </li>
                             <li class="nav-item" role="presentation">
-                                <a class="ms-1 btn btn-sm btn-secondary {% if query_filter == 'no-current' %}active {% endif %} scielo__btn-with-icon--left" href="{{ url_for('.collection_list_thematic') }}?status=no-current">
+                                <a class="ms-1 btn btn-sm btn-secondary {% if query_filter == 'no-current' %}active {% endif %} scielo__btn-with-icon--left" href="{{ url_for('.collection_list_thematic', status='no-current') }}">
                                 <span class="lbl-nao-corrente"><span class="material-icons" style="color: #c63800;">fiber_manual_record</span>{% trans %}Descontinuados{% endtrans %}</span>
                                 </a> 
                             </li>
@@ -180,7 +180,9 @@
 <script>
     function changeAreaFilter(event) {
         var currentPage = window.location.href.split('?')[0];
-        window.location = currentPage + "?status=" + "{{ query_filter }}" + "&filter=" + event.value;
+        var qs = "?status=" + "{{ query_filter }}" + "&filter=" + encodeURIComponent(event.value);
+        {% if g.lang %}qs += "&ilang={{ g.lang }}";{% endif %}
+        window.location = currentPage + qs;
     }
 </script>
 {% endblock %}
@@ -201,7 +203,7 @@
 
     $('.alpha-tab').click(function(event) {
 
-        window.location.href = "{{ url_for('.collection_list') }}?status=current";
+        window.location.href = "{{ url_for('.collection_list', status='current') }}";
 
     });
 

--- a/opac/webapp/templates/includes/footer.html
+++ b/opac/webapp/templates/includes/footer.html
@@ -25,7 +25,7 @@
 				{%- if footer_logo_url -%}
 					{{ img_macro.render_logo(footer_logo_url, coll_macro.get_collection_name()) }}
 				{%- else -%}
-					<a href="/" aria-label="{% trans %}Página inicial da coleção{% endtrans %} {{ coll_macro.get_collection_name() }}"><div class="scielo__logo-scielo--small" aria-hidden="true"></div></a>
+					<a href="{{ url_for('main.index') }}" aria-label="{% trans %}Página inicial da coleção{% endtrans %} {{ coll_macro.get_collection_name() }}"><div class="scielo__logo-scielo--small" aria-hidden="true"></div></a>
 				{%- endif -%}
 			</div>
 				<div class="col col-12 col-sm-8 text-center text-sm-start">

--- a/opac/webapp/templates/issue/grid.html
+++ b/opac/webapp/templates/issue/grid.html
@@ -12,7 +12,7 @@
       <div class="col ps-0">
 
         <ol class="breadcrumb mb-0 ps-0">
-          <li class="breadcrumb-item"><a href="{{ url_for('.collection_list') }}?status=current"><span class="material-icons-outlined">navigate_before</span> {% trans %}Periódicos{% endtrans %}</a></li>
+          <li class="breadcrumb-item"><a href="{{ url_for('.collection_list', status='current') }}"><span class="material-icons-outlined">navigate_before</span> {% trans %}Periódicos{% endtrans %}</a></li>
         </ol>
 
       </div>
@@ -33,7 +33,7 @@
 
           <ol class="breadcrumb mb-0 ps-0">
             <li class="breadcrumb-item"><a href="{{ url_for('.index') }}" alt="{% trans %}Home{% endtrans %}"><span class="material-icons-outlined">home</span></a></li>
-            <li class="breadcrumb-item"><a href="{{ url_for('.collection_list') }}?status=current">{% trans %}Periódicos{% endtrans %}</a></li>
+            <li class="breadcrumb-item"><a href="{{ url_for('.collection_list', status='current') }}">{% trans %}Periódicos{% endtrans %}</a></li>
             <li class="breadcrumb-item"><a href="{{ url_for('.journal_detail', url_seg=journal.url_segment) }}">{{ journal.title }}</a></li>
             <li class="breadcrumb-item">{% trans %}Todos os números{% endtrans %}</li>
           </ol>

--- a/opac/webapp/templates/issue/includes/alternative_header.html
+++ b/opac/webapp/templates/issue/includes/alternative_header.html
@@ -6,7 +6,7 @@
     <div class="col-md-2 col-sm-3 mainNav">
       <a href="#" class="menu" data-rel="#alternativeMainMenu" title="{% trans %}Abrir menu{% endtrans %}">{% trans %}Abrir menu{% endtrans %}</a>
       <h2 class="logo-svg-mini">
-        <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
+        <a href="{{ url_for('.index') }}" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
           <span class="logo-collection logo-collection-svg-mini"><strong>{{ coll_macro.get_collection_name() }}</strong></span>
         </a>
       </h2>

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -11,7 +11,7 @@
       <div class="col ps-0">
 
         <ol class="breadcrumb mb-0 ps-0">
-          <li class="breadcrumb-item"><a href="{{ url_for('.collection_list') }}?status=current"><span class="material-icons-outlined">navigate_before</span> {% trans %}Periódicos{% endtrans %}</a></li>
+          <li class="breadcrumb-item"><a href="{{ url_for('.collection_list', status='current') }}"><span class="material-icons-outlined">navigate_before</span> {% trans %}Periódicos{% endtrans %}</a></li>
         </ol>
 
       </div>
@@ -32,7 +32,7 @@
 
           <ol class="breadcrumb mb-0 ps-0">
             <li class="breadcrumb-item"><a href="{{ url_for('.index') }}" alt="{% trans %}Home{% endtrans %}"><span class="material-icons-outlined">home</span></a></li>
-            <li class="breadcrumb-item"><a href="{{ url_for('.collection_list') }}?status=current">{% trans %}Periódicos{% endtrans %}</a></li>
+            <li class="breadcrumb-item"><a href="{{ url_for('.collection_list', status='current') }}">{% trans %}Periódicos{% endtrans %}</a></li>
             <li class="breadcrumb-item"><a href="{{ url_for('.journal_detail', url_seg=journal.url_segment) }}">{{ journal.title }}</a></li>
             <li class="breadcrumb-item">{% trans %}Sumário{% endtrans %}</li>
           </ol>

--- a/opac/webapp/templates/journal/about.html
+++ b/opac/webapp/templates/journal/about.html
@@ -14,7 +14,7 @@
           <div class="col ps-0">
 
             <ol class="breadcrumb mb-0 ps-0">
-              <li class="breadcrumb-item"><a href="{{ url_for('.collection_list') }}?status=current"><span class="material-icons-outlined">navigate_before</span> {% trans %}Periódicos{% endtrans %}</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('.collection_list', status='current') }}"><span class="material-icons-outlined">navigate_before</span> {% trans %}Periódicos{% endtrans %}</a></li>
             </ol>
 
           </div>
@@ -36,7 +36,7 @@
 
             <ol class="breadcrumb mb-0 ps-0">
               <li class="breadcrumb-item"><a href="{{ url_for('.index') }}" alt="{% trans %}Home{% endtrans %}"><span class="material-icons-outlined">home</span></a></li>
-              <li class="breadcrumb-item"><a href="{{ url_for('.collection_list') }}?status=current">{% trans %}Periódicos{% endtrans %}</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('.collection_list', status='current') }}">{% trans %}Periódicos{% endtrans %}</a></li>
               <li class="breadcrumb-item"><a href="{{ url_for('.journal_detail', url_seg=journal.url_segment) }}">{{ journal.title }}</a></li>
               <li class="breadcrumb-item">{% trans %}Sobre o periódico{% endtrans %}</li>
             </ol>

--- a/opac/webapp/templates/journal/detail.html
+++ b/opac/webapp/templates/journal/detail.html
@@ -8,7 +8,7 @@
       <div class="col ps-0">
 
         <ol class="breadcrumb mb-0 ps-0">
-          <li class="breadcrumb-item"><a href="{{ url_for('.collection_list') }}?status=current"><span class="material-icons-outlined">navigate_before</span> {% trans %}Periódicos{% endtrans %}</a></li>
+          <li class="breadcrumb-item"><a href="{{ url_for('.collection_list', status='current') }}"><span class="material-icons-outlined">navigate_before</span> {% trans %}Periódicos{% endtrans %}</a></li>
         </ol>
 
       </div>
@@ -29,7 +29,7 @@
 
           <ol class="breadcrumb mb-0 ps-0">
             <li class="breadcrumb-item"><a href="{{ url_for('.index') }}" alt="{% trans %}Home{% endtrans %}"><span class="material-icons-outlined">home</span></a></li>
-            <li class="breadcrumb-item"><a href="{{ url_for('.collection_list') }}?status=current">{% trans %}Periódicos{% endtrans %}</a></li>
+            <li class="breadcrumb-item"><a href="{{ url_for('.collection_list', status='current') }}">{% trans %}Periódicos{% endtrans %}</a></li>
             <li class="breadcrumb-item">{{ journal.title }}</li>
           </ol>
           

--- a/opac/webapp/templates/journal/includes/alternative_header.html
+++ b/opac/webapp/templates/journal/includes/alternative_header.html
@@ -7,7 +7,7 @@
       <div class="col-md-2 --col-sm-3 mainNav">
         <a href="#" class="menu" data-rel="#alternativeMainMenu" title="{% trans %}Abrir menu{% endtrans %}">{% trans %}Abrir menu{% endtrans %}</a>
         <h2 class="logo-svg-mini">
-          <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
+          <a href="{{ url_for('.index') }}" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
             <span class="logo-collection logo-collection-svg-mini"><strong>{{ coll_macro.get_collection_name() }}</strong></span>
           </a>
         </h2>
@@ -143,12 +143,12 @@
       <div class="col-7">
         <!--
         <h2 class="logo-svg-mini">
-          <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
+          <a href="{{ url_for('.index') }}" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
             <span class="--logo-collection --logo-collection-svg-mini scielo__logo-scielo-collection"><strong>{{ coll_macro.get_collection_name() }}</strong></span>
           </a>
         </h2>
         -->
-        <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
+        <a href="{{ url_for('.index') }}" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
           <div class="scielo__logo-scielo-collection">
 						<small>{{ coll_macro.get_collection_name() }}</small>
 					</div>

--- a/opac/webapp/templates/journal/includes/header.html
+++ b/opac/webapp/templates/journal/includes/header.html
@@ -12,7 +12,7 @@
               {%- if header_logo_url -%}
                 {{ cimages.render_logo(header_logo_url, coll_macro.get_collection_name(), img_class='img-fluid scielo__logo-img my-1 ms-5') }}
               {%- else -%}
-                <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
+                <a href="{{ url_for('.index') }}" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
                   <div class="scielo__logo-scielo-collection my-1 ms-5">
                     <small id="collectionNameInternal">{{ coll_macro.get_collection_name() }}</small>
                   </div>

--- a/opac/webapp/templates/macros/images.html
+++ b/opac/webapp/templates/macros/images.html
@@ -41,9 +41,9 @@
 {%- endmacro %}
 
 
-{% macro render_logo(logo_url, collection_name, href='/', img_class='img-fluid scielo__logo-img') -%}
+{% macro render_logo(logo_url, collection_name, href=None, img_class='img-fluid scielo__logo-img') -%}
     {%- if logo_url -%}
-        <a href="{{ href }}"><img src="{{ logo_url }}" alt="{% trans %}Página inicial da coleção{% endtrans %} {{ collection_name }}" class="{{ img_class }}"></a>
+        <a href="{{ href or url_for('main.index') }}"><img src="{{ logo_url }}" alt="{% trans %}Página inicial da coleção{% endtrans %} {{ collection_name }}" class="{{ img_class }}"></a>
     {%- endif -%}
 {%- endmacro %}
 

--- a/opac/webapp/utils/i18n.py
+++ b/opac/webapp/utils/i18n.py
@@ -3,7 +3,7 @@
 
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
-from flask import current_app, request
+from flask import current_app, g, request, url_for as flask_url_for
 
 # Map primary language tags (and common variants) to LANGUAGES keys.
 _PRIMARY_TO_CANONICAL = {
@@ -96,6 +96,23 @@ def build_ilang_url(lang_code):
     args = request.args.to_dict(flat=True)
     args["ilang"] = lang_code
     return "%s?%s" % (request.path, urlencode(args))
+
+
+def _is_static_endpoint(endpoint):
+    if not endpoint:
+        return False
+    return endpoint == "static" or endpoint.endswith(".static")
+
+
+def url_for_with_ilang(endpoint, **values):
+    """
+    Like ``flask.url_for``, but injects ``ilang`` from the current interface locale.
+
+    Skips static endpoints. Does not overwrite an explicit ``ilang`` kwarg.
+    """
+    if not _is_static_endpoint(endpoint) and "ilang" not in values:
+        values["ilang"] = getattr(g, "lang", None) or get_locale()
+    return flask_url_for(endpoint, **values)
 
 
 def inject_ilang_into_url(url, lang_code, fragment=None):


### PR DESCRIPTION
## O que esse PR faz?

Garante que o idioma da interface (`ilang`) permaneça presente e correto na navegação interna do site público.

Antes, o seletor de idioma já gerava URLs com `?ilang=`, mas links de menu, breadcrumbs, lista alfabética/temática e logos (`href="/"`) usavam `url_for` sem `ilang`. Ao clicar, a interface caía no `Accept-Language` ou no default e “perdia” o idioma escolhido.

Este PR:
- Introduz `url_for_with_ilang` e sobrescreve o `url_for` do Jinja para injetar sempre `ilang=g.lang` (pula `static`; respeita `ilang` explícito)
- Corrige templates que concatenavam `url_for(...)}}?param` (evita URL inválida `?...?...`)
- Troca logos/home `href="/"` por `url_for('.index')` / `url_for('main.index')`
- Propaga `ilang` nos links gerados em `get_journal_json_data` e nos JS de filtro/download da lista
- Atualiza/adiciona testes de i18n, locale, header, menu e main views

Não altera `lang` de conteúdo (artigo/PDF/busca), nem monkeypatcha o `flask.url_for` usado em Python (redirects/admin/tests).

## Onde a revisão poderia começar?

1. [`opac/webapp/utils/i18n.py`](opac/webapp/utils/i18n.py) — `url_for_with_ilang`
2. [`opac/webapp/main/views.py`](opac/webapp/main/views.py) — registro do global Jinja `url_for`
3. [`opac/webapp/templates/collection/includes/nav.html`](opac/webapp/templates/collection/includes/nav.html) — exemplo de nav com `status` + `ilang`
4. [`opac/webapp/controllers.py`](opac/webapp/controllers.py) — links da lista de periódicos
5. [`opac/tests/test_interface_locale.py`](opac/tests/test_interface_locale.py) e [`opac/tests/test_utils_i18n.py`](opac/tests/test_utils_i18n.py)

## Como este poderia ser testado manualmente?

1. Subir o ambiente local e abrir a home com idioma explícito, ex.: `/?ilang=en`
2. Abrir o menu e clicar em **Lista alfabética de periódicos**
3. Confirmar que a URL resultante contém `ilang=en` (ex.: `/journals/alpha?status=current&ilang=en`) e que a interface permanece em inglês
4. Navegar para a lista temática, breadcrumbs de periódico/número e logo da home — o `ilang` deve continuar na URL
5. Trocar o idioma pelo seletor (ex.: EN → ES) e navegar de novo; o novo `ilang` deve ser preservado
6. (Opcional) Rodar os testes:

```bash
export OPAC_CONFIG="config/templates/testing.template" && \
flask --app opac.app test -p test_utils_i18n && \
flask --app opac.app test -p test_interface_locale && \
flask --app opac.app test -p test_interface_header && \
flask --app opac.app test -p test_interface_menu && \
flask --app opac.app test -p test_main_views
```

## Algum cenário de contexto que queira dar?

O idioma da interface passou a ser resolvido por query string (`ilang`) / `Accept-Language` / default, sem session/cookie (ver PR #508). Sem propagar `ilang` nos links internos, a escolha do usuário se perdia na primeira navegação — especialmente perceptível na lista alfabética a partir da home.

`lang` (conteúdo) e `ilang` (interface) continuam conceitos distintos.

## Screenshots

N/A 

## Quais são os tickets relevantes?

Continuidade de #508 (`chore/interface-language-from-query-string`).

## Referências

- Flask `url_for` e query string kwargs
- Flask-Babel `locale_selector` / resolução de locale via `get_locale`

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): alteração apenas de geração de URLs internas e testes; sem novas deps/endpoints. Validação via pipeline do PR quando aberto.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)
