### PR TITLE
fix(templates): sincroniza correção da âncora de política editorial (#516) para qa

### DIFF
--- a/opac/tests/test_utils.py
+++ b/opac/tests/test_utils.py
@@ -523,3 +523,39 @@ class UtilsTestCase(BaseTestCase):
             self.assertIsNone(wutils.generate_thumbnail("/tmp/broken.png"))
         finally:
             current_app.config["IMAGE_ROOT"] = original_image_root
+
+    # extract_section / normalize_policy_anchor (issue #516)
+    def test_extract_section_returns_none_when_section_not_found(self):
+        html = "<html><body><p>sem seção journalContent</p></body></html>"
+        self.assertIsNone(wutils.extract_section(html, "journalContent"))
+
+    def test_extract_section_adds_policy_anchor_for_legacy_item_2_id(self):
+        html = (
+            '<section class="journalContent">'
+            '<h1 id="about">Sobre o periódico</h1>'
+            '<h4 id="item-2">Política editorial</h4>'
+            "</section>"
+        )
+        result = wutils.extract_section(html, "journalContent")
+        self.assertIn('id="policy"', result)
+        self.assertIn('id="item-2"', result)
+
+    def test_extract_section_keeps_existing_policy_id_untouched(self):
+        html = (
+            '<section class="journalContent">'
+            '<h1 id="about">Sobre o periódico</h1>'
+            '<a id="policy" name="policy"> </a>'
+            "<h4>Política editorial</h4>"
+            "</section>"
+        )
+        result = wutils.extract_section(html, "journalContent")
+        self.assertEqual(result.count('id="policy"'), 1)
+
+    def test_extract_section_does_not_add_policy_anchor_when_no_legacy_id(self):
+        html = (
+            '<section class="journalContent">'
+            '<h1 id="about">Sobre o periódico</h1>'
+            "</section>"
+        )
+        result = wutils.extract_section(html, "journalContent")
+        self.assertNotIn("policy", result)

--- a/opac/webapp/templates/article/includes/header.html
+++ b/opac/webapp/templates/article/includes/header.html
@@ -137,7 +137,7 @@
                   </li>
 
                   <li>
-                    <a href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#item2" class="dropdown-item">
+                    <a href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#policy" class="dropdown-item">
                       <span class="material-icons-outlined" aria-hidden="true">help_outline</span>
                       {% trans %}Política editorial{% endtrans %}
                     </a>

--- a/opac/webapp/templates/collection/includes/journal_list_row.html
+++ b/opac/webapp/templates/collection/includes/journal_list_row.html
@@ -45,7 +45,7 @@
           {% if journal.is_active  %}
             <a class="btn btn-secondary scielo__btn-with-icon--only" data-toggle="tooltip" href="{{ journal.links.submission }}" title="{% trans %}Submissão de manuscritos{% endtrans %}" target="_blank"><span class="material-icons-outlined">launch</span></a>
             <a class="btn btn-secondary scielo__btn-with-icon--only" data-toggle="tooltip" href="{{ journal.links.about }}" title="{% trans %}Sobre o periódico{% endtrans %}"><span class="material-icons-outlined">info</span></a>
-            <a class="btn btn-secondary scielo__btn-with-icon--only" data-toggle="tooltip" href="{{ journal.links.about }}#item-2" title="{% trans %}Política editorial{% endtrans %}"><span class="material-icons-outlined">article</span></a>
+            <a class="btn btn-secondary scielo__btn-with-icon--only" data-toggle="tooltip" href="{{ journal.links.about }}#policy" title="{% trans %}Política editorial{% endtrans %}"><span class="material-icons-outlined">article</span></a>
             <a class="btn btn-secondary scielo__btn-with-icon--only" data-toggle="tooltip" href="{{ journal.links.editors }}" title="{% trans %}Corpo Editorial{% endtrans %}"><span class="material-icons-outlined">people</span></a>
             <a class="btn btn-secondary scielo__btn-with-icon--only" data-toggle="tooltip" href="{{ journal.links.instructions }}" title="{% trans %}Instruções aos autores{% endtrans %}"><span class="material-icons-outlined">help_outline</span></a>
             <a class="btn btn-secondary scielo__btn-with-icon--only" data-toggle="tooltip" href="{{ journal.links.contact }}" title="{% trans %}Contato{% endtrans %}"><span class="material-icons-outlined">markunread</span></a>

--- a/opac/webapp/templates/journal/includes/header.html
+++ b/opac/webapp/templates/journal/includes/header.html
@@ -47,7 +47,7 @@
                       <a href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#instructions" class="dropdown-item"><span class="material-icons-outlined">help_outline</span> {% trans %}Instruções aos autores{% endtrans %}</a>
                     </li>
                     <li>
-                      <a href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#item2" class="dropdown-item"><span class="material-icons-outlined">help_outline</span> {% trans %}Política editorial{% endtrans %}</a>
+                      <a href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#policy" class="dropdown-item"><span class="material-icons-outlined">help_outline</span> {% trans %}Política editorial{% endtrans %}</a>
                     </li>
                     <li>
                       <a href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#contact" class="dropdown-item"><span class="material-icons-outlined">email</span> {% trans %}Contato{% endtrans %}</a>
@@ -90,7 +90,7 @@
                   <a href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#instructions" class="dropdown-item"><span class="material-icons-outlined">help_outline</span> {% trans %}Instruções aos autores{% endtrans %}</a>
                 </li>
                 <li>
-                  <a href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#item2" class="dropdown-item"><span class="material-icons-outlined">article</span> {% trans %}Política editorial{% endtrans %}</a>
+                  <a href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#policy" class="dropdown-item"><span class="material-icons-outlined">article</span> {% trans %}Política editorial{% endtrans %}</a>
                 </li>
                 <li>
                   <a href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#contact" class="dropdown-item"><span class="material-icons-outlined">email</span> {% trans %}Contato{% endtrans %}</a>

--- a/opac/webapp/templates/journal/includes/journal_info.html
+++ b/opac/webapp/templates/journal/includes/journal_info.html
@@ -95,7 +95,7 @@
             <a class="list-group-item" href="{{ journal.online_submission_url|default('', true) }}" target="_blank"><span class="material-icons-outlined">launch</span> {% trans %}Submissão de manuscritos{% endtrans %}</a>
           {% endif %}
             <a class="list-group-item" href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#about" class="scroll"><span class="material-icons-outlined">info</span> {% trans %}Sobre o periódico{% endtrans %}</a>
-            <a class="list-group-item" href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#item-2" class="scroll"><span class="material-icons-outlined">article</span> {% trans %}Política editorial{% endtrans %}</a>
+            <a class="list-group-item" href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#policy" class="scroll"><span class="material-icons-outlined">article</span> {% trans %}Política editorial{% endtrans %}</a>
             <a class="list-group-item" href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#editors" class="scroll"><span class="material-icons-outlined">people</span> {% trans %}Corpo Editorial{% endtrans %}</a>
             <a class="list-group-item" href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#instructions" class="scroll"><span class="material-icons-outlined">help_outline</span> {% trans %}Instruções aos autores{% endtrans %}</a>
             <a class="list-group-item" href="{{ url_for('.about_journal', url_seg=journal.url_segment) }}#contact" class="scroll"><span class="material-icons-outlined">markunread</span> {% trans %}Contato{% endtrans %}</a>

--- a/opac/webapp/utils/utils.py
+++ b/opac/webapp/utils/utils.py
@@ -793,6 +793,23 @@ def replace_link(section):
     return section
 
 
+def normalize_policy_anchor(soup, section):
+    """
+    Períodicos migrados para o novo gerador de conteúdo (core.scielo.org)
+    entregam a seção "Política editorial" com o id semântico "policy", mas
+    períodicos ainda no fluxo antigo entregam essa mesma seção com o id
+    numérico legado "item-2". Garante que "#policy" funcione nos dois casos,
+    adicionando uma âncora extra sem remover o id legado.
+    """
+    if section.find(id="policy"):
+        return section
+    legacy_anchor = section.find(id="item-2")
+    if legacy_anchor:
+        policy_anchor = soup.new_tag("a", id="policy")
+        legacy_anchor.insert_before(policy_anchor)
+    return section
+
+
 def normalize_lang_portuguese(language):
     if language == "pt_BR":
         return "pt-br"
@@ -803,11 +820,11 @@ def normalize_lang_portuguese(language):
 def extract_section(html_content, class_name):
     soup = BeautifulSoup(html_content, "html.parser")
     section = soup.find("section", class_=class_name)
-    section = replace_link(section=section)
-    if section:
-        return str(section)
-    else:
+    if not section:
         return None
+    section = replace_link(section=section)
+    section = normalize_policy_anchor(soup, section)
+    return str(section)
 
 
 def fetch_and_extract_section(collection_acronym, journal_acronym, language):


### PR DESCRIPTION
## O que esse PR faz?

Sincroniza para `qa` o fix da âncora de política editorial (issue #516 / PR #521), que foi mergeado apenas em `master` e nunca chegou a `qa` — e, por consequência, nunca foi liberado em produção (as tags de release são cortadas a partir de `qa`).

Traz os 3 commits originais do PR #521 via cherry-pick, sem alterações de conteúdo:
- `fix(templates)`: troca `#item2`/`#item-2` por `#policy` nos links de menu (`article/includes/header.html`, `journal/includes/header.html`, `journal/includes/journal_info.html`, `collection/includes/journal_list_row.html`)
- `fix(utils)`: adiciona `normalize_policy_anchor()` em `utils.py`, garantindo que `#policy` funcione tanto em periódicos com id legado (`item-2`) quanto nos já migrados ao novo gerador de conteúdo
- `test(utils)`: testes unitários para `normalize_policy_anchor()`/`extract_section()`

Houve um único conflito de merge em `opac/tests/test_utils.py` (dois blocos de teste independentes inseridos no mesmo ponto do arquivo, um deles de uma feature que só existe em `qa`) — resolvido mantendo ambos os blocos, sem alteração de lógica.

## Onde a revisão poderia começar?

1. [`opac/webapp/utils/utils.py`](opac/webapp/utils/utils.py) — `normalize_policy_anchor()`
2. [`opac/tests/test_utils.py`](opac/tests/test_utils.py) — testes novos + resolução do conflito

## Como este poderia ser testado manualmente?

1. Subir o ambiente local e acessar a página "Sobre o periódico" de um periódico com conteúdo legado (ex.: `aabc`, id `item-2`) e de um já migrado (ex.: `abcic`, id `policy`)
2. Clicar no item "Política editorial" do menu em ambos
3. Confirmar que em ambos os casos a página rola até a seção correta

Testes automatizados: `flask --app opac.app test -p test_utils` — 21 testes, incluindo os 4 novos de `normalize_policy_anchor`/`extract_section`, todos passando.

## Algum cenário de contexto que queira dar?

Este é puramente um PR de sincronização entre branches — o código já foi revisado e aprovado no PR #521. A urgência vem de um report de produção: o periódico RBCA/BJPS reportou que o link "Política editorial" não funciona em `scielo.br`, e a investigação mostrou que o fix nunca chegou a `qa`/produção, apesar de já estar em `master` desde 30/07.

## Quais são os tickets relevantes?

Closes #526 (relacionado: #516, PR #521)

## Referências

- #516
- PR #521
- #526

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Não aplicável a este PR (justifique): mudança restrita a templates/HTML estático e a uma função de parsing de HTML já existente (BeautifulSoup), idêntica ao código já aprovado no PR #521 — apenas sincronizando branch.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [x] Não — `normalize_policy_anchor()` apenas inspeciona/insere um atributo `id` fixo via BeautifulSoup; não interpola dados de entrada em HTML/SQL.

**Este PR expõe novos endpoints, telas ou serviços?**
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
