### PR TITLE
fix(i18n): corrige tradução fuzzy de 'Política editorial' em en/es/es_ES

### DIFF
--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -1687,9 +1687,8 @@ msgstr "Journal home page"
 #: opac/webapp/templates/journal/includes/header.html:50
 #: opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/journal_info.html:98
-#, fuzzy
 msgid "Política editorial"
-msgstr "Editorial Board"
+msgstr "Editorial Policy"
 
 #: opac/webapp/templates/article/includes/levelMenu.html:8
 #: opac/webapp/templates/article/includes/levelMenu.html:326

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -1690,9 +1690,8 @@ msgstr "Inicio de la revista"
 #: opac/webapp/templates/journal/includes/header.html:50
 #: opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/journal_info.html:98
-#, fuzzy
 msgid "Política editorial"
-msgstr "Cuerpo Editorial"
+msgstr "Política Editorial"
 
 #: opac/webapp/templates/article/includes/levelMenu.html:8
 #: opac/webapp/templates/article/includes/levelMenu.html:326

--- a/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
@@ -1665,9 +1665,8 @@ msgstr "Inicio de la revista"
 #: opac/webapp/templates/journal/includes/header.html:50
 #: opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/journal_info.html:98
-#, fuzzy
 msgid "Política editorial"
-msgstr "Cuerpo Editorial"
+msgstr "Política Editorial"
 
 #: opac/webapp/templates/article/includes/levelMenu.html:8
 #: opac/webapp/templates/article/includes/levelMenu.html:326

--- a/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
@@ -1637,7 +1637,7 @@ msgstr ""
 #: opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/journal_info.html:98
 msgid "Política editorial"
-msgstr ""
+msgstr "Política Editorial"
 
 #: opac/webapp/templates/article/includes/levelMenu.html:8
 #: opac/webapp/templates/article/includes/levelMenu.html:326

--- a/opac/webapp/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/pt_PT/LC_MESSAGES/messages.po
@@ -1618,7 +1618,7 @@ msgstr ""
 #: opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/journal_info.html:98
 msgid "Política editorial"
-msgstr ""
+msgstr "Política editorial"
 
 #: opac/webapp/templates/article/includes/levelMenu.html:8
 #: opac/webapp/templates/article/includes/levelMenu.html:326


### PR DESCRIPTION
## O que esse PR faz?

Corrige a tradução do item de menu "Política editorial", que aparecia sempre em português independente do idioma da interface.

Causa raiz: o `msgid "Política editorial"` estava marcado `#, fuzzy` nos catálogos `en`, `es` e `es_ES` desde novembro/2024 (commit `d3bd7921`), com um `msgstr` incorreto — "Editorial Board" / "Cuerpo Editorial", que na verdade é a tradução de "Corpo Editorial" (outro item de menu). Como `pybabel compile` (usado pelo `make compile_messages`) ignora entradas fuzzy por padrão, essa string nunca era compilada no `.mo` e o gettext caía no `msgid` original em português, em qualquer idioma.

Este PR:
- Corrige `en` → "Editorial Policy" e `es`/`es_ES` → "Política Editorial", removendo a flag `#, fuzzy`
- Preenche `es_MX` e `pt_PT`, que estavam com `msgstr` vazio

## Onde a revisão poderia começar?

[`opac/webapp/translations/en/LC_MESSAGES/messages.po`](opac/webapp/translations/en/LC_MESSAGES/messages.po) — busque por `Política editorial`

## Como este poderia ser testado manualmente?

1. `make compile_messages` (ou `pybabel compile -d opac/webapp/translations`)
2. Acessar a página de um periódico com `?ilang=en` e `?ilang=es`
3. Confirmar que o item de menu exibe "Editorial Policy" / "Política Editorial"

Validado localmente via `gettext.translation(...).gettext("Política editorial")` nas 5 locales — todas retornando a tradução correta após compilar.

## Algum cenário de contexto que queira dar?

Bug pré-existente (não relacionado à sincronização feita no PR #529 / issue #526), identificado durante a investigação do report urgente do periódico RBCA/BJPS: "o menu EDITORIAL POLICY está em português, mesmo alterando a interface para Inglês."

## Quais são os tickets relevantes?

Closes #527

## Referências

- #527
- #526 (mesma origem do report, causa raiz diferente)

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Não aplicável a este PR (justifique): mudança restrita a conteúdo estático de catálogos de tradução (`.po`), sem lógica de código.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
