### PR TITLE
Atualiza Flask, Werkzeug, urllib3 e lxml

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-Flask-DebugToolbar==0.13.1
+Flask-DebugToolbar==0.16.0
 Flask-Testing==0.8.1
 mock==5.0.1
 coverage==7.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ email-validator==2.3.0
 feedparser==6.0.12
 feedwerk==1.2.0
 filelock==3.29.6
-Flask==3.1.2
+Flask==3.1.3
 Flask-Admin==2.2.0
 Flask-Babel==4.0.0
 Flask-Caching==2.4.0
@@ -39,7 +39,7 @@ idna==3.18
 itsdangerous==2.2.0
 Jinja2==3.1.6
 legendarium==2.0.6
-lxml==5.3.0
+lxml==6.1.1
 Mako==1.3.12
 MarkupSafe==3.0.2
 mongoengine==0.29.3
@@ -76,9 +76,9 @@ text-unidecode==1.3
 tox==4.56.2
 tweepy==4.17.0
 Unidecode==1.4.0
-urllib3==1.26.14
+urllib3==2.7.0
 virtualenv==21.6.0
-Werkzeug==3.1.3
+Werkzeug==3.1.8
 wrapt==1.14.1
 WTForms==3.2.2
 XlsxWriter==3.2.9


### PR DESCRIPTION
## O que esse PR faz?

Atualiza pins de segurança em `requirements.txt` para versões sem advisories OSV/Dependabot abertos:

| Pacote | Antes | Depois |
|---|---|---|
| Flask | 3.1.2 | 3.1.3 |
| Werkzeug | 3.1.3 | 3.1.8 |
| urllib3 | 1.26.14 | 2.7.0 |
| lxml | 5.3.0 | 6.1.1 |

Fecha o cluster de alertas relacionado a:

- **urllib3** — vários HIGH (redirect headers, decompression bombs / streaming API); `1.26.19` não fecha os HIGH de 2025/2026; alvo limpo é `2.7.0`
- **lxml** — XXE em `iterparse` / `ETCompatXMLParser` (CVE-2026-41066 / GHSA-vfmq-68hx-4jfw)
- **Werkzeug** — `safe_join` e device names Windows
- **Flask** — LOW: `Vary: Cookie` em alguns acessos a session

Não há mudança de código de aplicação; apenas bumps de dependências.

PR: https://github.com/scieloorg/opac_5/pull/534

## Onde a revisão poderia começar?

1. [`requirements.txt`](../requirements.txt) — pins atualizados
2. Uso de HTTP em [`opac/webapp/utils/utils.py`](../opac/webapp/utils/utils.py) (`fetch_data` / `requests`) — impacto urllib3 2.x
3. Render XML→HTML em [`opac/webapp/main/views.py`](../opac/webapp/main/views.py) (`etree.parse` + packtools) — impacto lxml 6.x

## Como este poderia ser testado manualmente?

1. Instalar os pins novos: `pip install -r requirements.txt` (ou rebuild Docker se o deploy usa imagem)
2. Confirmar versões:
   ```bash
   python -c "from importlib.metadata import version as v; print(v('Flask'), v('Werkzeug'), v('urllib3'), v('lxml'))"
   ```
   Esperado: `3.1.3 3.1.8 2.7.0 6.1.1`
3. Rodar a suite: `make test`
4. Smoke HTTP (urllib3 2.x via `requests` / `fetch_data`):
   - Abrir um artigo em HTML gerado a partir de XML
   - Baixar PDF de artigo
   - Abrir página about da coleção / conteúdo vindo do core, se aplicável
5. Smoke lxml 6.x: validar renderização HTML a partir de XML (packtools / `render_html_from_xml`) em pelo menos um periódico com XML
6. Smoke Flask/Werkzeug: login no admin e navegação em página pública (session / cookies)
7. Após merge: conferir alertas em https://github.com/scieloorg/opac_5/security/dependabot como Resolved

## Algum cenário de contexto que queira dar?

O inventário foi cruzado com [OSV](https://osv.dev) contra os pins de `requirements.txt`. Permanecer em urllib3 1.26.x deixa HIGH abertos (CVE-2025-66418, CVE-2025-66471, CVE-2026-21441, CVE-2026-44431, CVE-2026-44432). `requests==2.34.2` já aceita `urllib3>=1.26,<3`.

Stack Pallets já estava na linha Flask/Werkzeug 3.1.x; este PR é só patch de segurança, sem nova onda de migração.

Validação automatizada local: `make test` — 1237 OK (15 skipped).

## Screenshots

N/A — alteração apenas de pins em `requirements.txt`; sem mudança visual de interface.

## Quais são os tickets relevantes?

Relacionado aos alertas em https://github.com/scieloorg/opac_5/security/dependabot

## Referências

- OSV / GHSA urllib3: GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53, GHSA-38jv-5279-wg99, GHSA-qccp-gfcp-xxvc, GHSA-mf9v-mfxr-j63j (fixos em ≥2.7.0)
- lxml XXE: [GHSA-vfmq-68hx-4jfw](https://github.com/lxml/lxml/security/advisories/GHSA-vfmq-68hx-4jfw) / CVE-2026-41066 (fixo em ≥6.1.0)
- Werkzeug: GHSA-hgf8-39gv-g3f2, GHSA-87hc-h4r5-73f7, GHSA-29vq-49wr-vm6x (fixos em ≥3.1.6)
- Flask: GHSA-68rp-wp8r-4726 / CVE-2026-27205 (fixo em 3.1.3)
- PyPI: Flask 3.1.3, Werkzeug 3.1.8, urllib3 2.7.0, lxml 6.1.1

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [x] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [x] Pendente / vulnerabilidade aceita com justificativa: bumps escolhidos via OSV para versões com 0 GHSA abertos nesses pacotes (Flask 3.1.3, Werkzeug 3.1.8, urllib3 2.7.0, lxml 6.1.1); validação SBOM/Trivy do pipeline permanece a confirmar no CI do PR
- [ ] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): validação local via OSV + `make test`; aguarda job de segurança do CI no PR #534

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)
