### PR TITLE
fix(admin): sincroniza conteúdo do CKEditor 5 no submit de Pages

### DIFF
--- a/opac/tests/test_admin_pages_ckeditor.py
+++ b/opac/tests/test_admin_pages_ckeditor.py
@@ -48,6 +48,8 @@ class PagesCKEditor5Tests(AdminViewsCoverageMixin, BaseTestCase):
         self.assertIn('licenseKey: "GPL"', editor_js)
         self.assertIn("htmlSupport", editor_js)
         self.assertIn("ClassicEditor.create", editor_js)
+        self.assertIn("updateSourceElement", editor_js)
+        self.assertIn("change:data", editor_js)
         self.assertIn("OPAC_CKEDITOR_LANG", editor_js)
         for feature in (
             "Fullscreen",
@@ -93,6 +95,11 @@ class PagesCKEditor5Tests(AdminViewsCoverageMixin, BaseTestCase):
                     )
                     self.assertIn('window.OPAC_CKEDITOR_LANG = "pt-br"', body)
                     self.assertIn("/static/js/ckeditor5/opac-pages-editor.js", body)
+                    asset_v = current_app.config.get("VCS_REF") or current_app.config.get(
+                        "WEBAPP_VERSION"
+                    )
+                    if asset_v:
+                        self.assertIn("opac-pages-editor.js?v=%s" % asset_v, body)
                     self.assertIn('id="content"', body)
                     self.assertNotIn("/static/js/ckeditor/ckeditor.js", body)
 

--- a/opac/webapp/static/js/ckeditor5/opac-pages-editor.js
+++ b/opac/webapp/static/js/ckeditor5/opac-pages-editor.js
@@ -339,6 +339,10 @@
             if (editable) {
                 editable.style.minHeight = "500px";
             }
+
+            editor.model.document.on("change:data", function () {
+                editor.updateSourceElement();
+            });
         })
         .catch(function (error) {
             console.error("CKEditor 5 init failed", error);

--- a/opac/webapp/templates/admin/pages/_ckeditor5.html
+++ b/opac/webapp/templates/admin/pages/_ckeditor5.html
@@ -14,4 +14,4 @@
 <script>
     window.OPAC_CKEDITOR_LANG = {{ ck_lang|tojson }};
 </script>
-<script src="/static/js/ckeditor5/opac-pages-editor.js"></script>
+<script src="{{ url_for('static', filename='js/ckeditor5/opac-pages-editor.js', v=config.VCS_REF or config.WEBAPP_VERSION) }}"></script>


### PR DESCRIPTION
## O que esse PR faz?

Corrige o submit do formulário de Pages no admin (`/admin/pages/new/` e `/admin/pages/edit/`).

O CKEditor 5 oculta o `<textarea name="content" required>`. O texto digitado ficava só na interface do editor, e o textarea original permanecia vazio. Na hora de salvar, a validação HTML5 do navegador bloqueava o envio com:

```
An invalid form control with name='content' is not focusable.
```

Este PR sincroniza o HTML do editor com o textarea a cada alteração (`change:data` → `updateSourceElement()`), mantendo o atributo `required`. Também versiona o JS estático com `VCS_REF` ou `WEBAPP_VERSION` para o navegador carregar o arquivo novo após o deploy.

## Onde a revisão poderia começar?

1. `opac/webapp/static/js/ckeditor5/opac-pages-editor.js` — sincronização do conteúdo
2. `opac/webapp/templates/admin/pages/_ckeditor5.html` — cache busting do asset
3. `opac/tests/test_admin_pages_ckeditor.py` — asserts da correção

## Como este poderia ser testado manualmente?

1. Acessar o admin autenticado.
2. Ir em **Pages** → **Create** (`/admin/pages/new/`).
3. Preencher os campos obrigatórios (nome, slug, idioma etc.).
4. Digitar conteúdo no CKEditor 5.
5. Clicar em **Save**.
6. Confirmar que o formulário é enviado e a página é criada.
7. Repetir o fluxo em **Edit** (`/admin/pages/edit/`).

Opcional: no DevTools → Elements, após digitar no editor, o `<textarea id="content">` deve conter o HTML (não ficar vazio).

## Algum cenário de contexto que queira dar?

O CKEditor 5 substitui visualmente o textarea do WTForms e o oculta com `display: none`. A validação HTML5 nativa ocorre **antes** do evento `submit`, então sincronizar só no submit chega tarde demais. A solução mínima é copiar o conteúdo do editor para o textarea a cada `change:data`.

O `required` foi mantido. A validação de campo obrigatório continua no HTML5 e no servidor.

O query param `v` usa `config.VCS_REF` ou `config.WEBAPP_VERSION` (já definidos no build Docker) para invalidar o cache de estáticos após cada deploy, sem data hardcoded.

## Screenshots

Problema original (console):

https://github.com/scieloorg/opac_5/issues/538

## Quais são os tickets relevantes?

Closes https://github.com/scieloorg/opac_5/issues/538

## Referências

- [CKEditor 5 `updateSourceElement()`](https://ckeditor.com/docs/ckeditor5/latest/api/module_editor-classic_classiceditor-ClassicEditor.html#function-updateSourceElement)
- Issue #538

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): alteração pontual de JS/template/teste no admin; o pipeline de CI da PR deve executar após a abertura.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)

Made with [Cursor](https://cursor.com)