### PR TITLE
Atualiza issue pelo pid para não duplicar fascículo quando o _id muda

### DIFF
--- a/opac/tests/test_controller_coverage.py
+++ b/opac/tests/test_controller_coverage.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from flask import current_app
 from flask_babel import gettext as __
-from opac_schema.v1.models import Article, News, PressRelease
+from opac_schema.v1.models import Article, Issue, News, PressRelease
 from webapp import controllers
 from webapp.controllers import ArticleJournalNotFoundError
 
@@ -981,6 +981,149 @@ class FactoryWrapperCoverageTests(BaseTestCase):
             "http://minio.scielo.org/documentstore/example.xml",
         )
         self.assertEqual(article.aid, "article-coverage-id")
+
+
+class AddIssuePidUpsertTests(BaseTestCase):
+    def _issue_payload(self, issue_id, pid, **overrides):
+        data = {
+            "id": issue_id,
+            "publication_year": "2020",
+            "volume": "1",
+            "number": "1",
+            "publication_months": {"range": [1, 3]},
+            "pid": pid,
+            "created": "2020-01-01T00:00:00.000000Z",
+            "updated": "2020-01-02T00:00:00.000000Z",
+        }
+        data.update(overrides)
+        return data
+
+    def test_add_issue_updates_by_pid_when_id_changes_and_relinks_articles(self):
+        journal = utils.makeOneJournal({"_id": "0000-pid-1"})
+        pid = "0000pid120200002"
+        old_id = "0000-pid-1-2020-v1-n1"
+        new_id = "0000-pid-1-2020-v1"
+
+        controllers.add_issue(self._issue_payload(old_id, pid), journal.jid)
+        article = utils.makeOneArticle({"journal": journal, "issue": old_id})
+
+        updated = controllers.add_issue(
+            self._issue_payload(new_id, pid, number=None),
+            journal.jid,
+        )
+
+        self.assertEqual(updated._id, new_id)
+        self.assertEqual(updated.pid, pid)
+        self.assertEqual(Issue.objects.filter(pid=pid).count(), 1)
+        self.assertIsNone(Issue.objects.filter(_id=old_id).first())
+
+        article.reload()
+        self.assertEqual(article.issue.id, new_id)
+
+    def test_add_issue_does_not_relink_articles_when_id_is_unchanged(self):
+        journal = utils.makeOneJournal({"_id": "0000-pid-2"})
+        pid = "0000pid220200002"
+        issue_id = "0000-pid-2-2020-v1-n1"
+
+        controllers.add_issue(self._issue_payload(issue_id, pid), journal.jid)
+        article = utils.makeOneArticle({"journal": journal, "issue": issue_id})
+
+        updated = controllers.add_issue(
+            self._issue_payload(issue_id, pid, publication_year="2021"),
+            journal.jid,
+        )
+
+        self.assertEqual(updated._id, issue_id)
+        self.assertEqual(Issue.objects.count(), 1)
+        article.reload()
+        self.assertEqual(article.issue.id, issue_id)
+
+    def test_add_issue_merges_duplicate_issues_with_same_pid(self):
+        journal = utils.makeOneJournal({"_id": "0000-pid-3"})
+        pid = "0000pid320200002"
+        old_id = "0000-pid-3-2020-v1-n1"
+        new_id = "0000-pid-3-2020-v1"
+
+        old_issue = utils.makeOneIssue(
+            {"_id": old_id, "journal": journal, "pid": pid, "number": "1"}
+        )
+        utils.makeOneIssue(
+            {"_id": new_id, "journal": journal, "pid": pid, "number": None}
+        )
+        article = utils.makeOneArticle({"journal": journal, "issue": old_issue})
+
+        updated = controllers.add_issue(
+            self._issue_payload(new_id, pid, number=None),
+            journal.jid,
+        )
+
+        self.assertEqual(updated._id, new_id)
+        self.assertEqual(Issue.objects.filter(pid=pid).count(), 1)
+        self.assertIsNone(Issue.objects.filter(_id=old_id).first())
+        article.reload()
+        self.assertEqual(article.issue.id, new_id)
+
+    def test_add_issue_without_pid_creates_issue(self):
+        journal = utils.makeOneJournal({"_id": "0000-pid-4"})
+        issue_id = "0000-pid-4-2020-v1-n1"
+        payload = self._issue_payload(issue_id, pid="")
+        payload.pop("pid")
+
+        created = controllers.add_issue(payload, journal.jid)
+
+        self.assertEqual(created._id, issue_id)
+        self.assertEqual(Issue.objects.count(), 1)
+
+    def test_add_issue_creates_new_record_when_pid_is_unknown(self):
+        journal = utils.makeOneJournal({"_id": "0000-pid-5"})
+        utils.makeOneIssue(
+            {
+                "_id": "0000-pid-5-2020-v1-n1",
+                "journal": journal,
+                "pid": "0000pid520200001",
+            }
+        )
+
+        created = controllers.add_issue(
+            self._issue_payload("0000-pid-5-2020-v2-n1", "0000pid520200002"),
+            journal.jid,
+        )
+
+        self.assertEqual(created._id, "0000-pid-5-2020-v2-n1")
+        self.assertEqual(Issue.objects.count(), 2)
+
+    def test_add_issue_relinks_press_release_and_last_issue_iid(self):
+        old_id = "0000-pid-6-2020-v1-n1"
+        new_id = "0000-pid-6-2020-v1"
+        pid = "0000pid620200002"
+        last_issue = utils.getLastIssue({"iid": old_id, "url_segment": "2020.v1n1"})
+        journal = utils.makeOneJournal(
+            {"_id": "0000-pid-6", "last_issue": last_issue}
+        )
+        controllers.add_issue(self._issue_payload(old_id, pid), journal.jid)
+        article = utils.makeOneArticle({"journal": journal, "issue": old_id})
+        press_release = PressRelease(
+            _id=str(uuid4().hex),
+            title="PR",
+            language="pt",
+            content="<p>content</p>",
+            journal=journal.id,
+            issue=old_id,
+            article=article.id,
+            url="http://example.com/pr",
+            publication_date=datetime.datetime(2024, 1, 1),
+        ).save()
+
+        updated = controllers.add_issue(
+            self._issue_payload(new_id, pid, number=None),
+            journal.jid,
+        )
+
+        press_release.reload()
+        journal.reload()
+        self.assertEqual(press_release.issue.id, new_id)
+        self.assertEqual(journal.last_issue.iid, updated.iid)
+        self.assertEqual(Issue.objects.filter(_id=old_id).count(), 0)
 
 
 class RemainingControllersCoverageTests(BaseTestCase):

--- a/opac/tests/test_factory.py
+++ b/opac/tests/test_factory.py
@@ -13,6 +13,7 @@ from webapp.factory import (
     IssueFactory,
     JournalFactory,
     _format_author_name,
+    _get_issue_for_upsert,
     isoformat_to_datetime,
 )
 
@@ -249,7 +250,8 @@ class IssueFactoryTestCase(BaseTestCase):
             first.save()
 
             data["publication_year"] = "2021"
-            updated = IssueFactory(data, journal_id=None)
+            issue, _ = _get_issue_for_upsert(data)
+            updated = IssueFactory(data, journal_id=None, issue=issue)
 
             self.assertEqual(updated._id, first._id)
             self.assertEqual(updated.journal._id, self.journal._id)
@@ -348,6 +350,94 @@ class IssueFactoryTestCase(BaseTestCase):
                 _type="special",
             )
             self.assertEqual(issue.type, "special")
+
+    def test_get_issue_for_upsert_finds_by_pid_when_id_changes(self):
+        with current_app.app_context():
+            data = _minimal_issue_data(
+                self.journal._id,
+                issue_id="0000-0003-2020-v1-n1",
+                pid="0000000320200002",
+            )
+            original = IssueFactory(data, self.journal._id)
+            original.save()
+
+            data["id"] = "0000-0003-2020-v1"
+            data["number"] = None
+            issue, old_ids = _get_issue_for_upsert(data)
+
+            self.assertEqual(old_ids, ["0000-0003-2020-v1-n1"])
+            self.assertEqual(issue._id, original._id)
+            self.assertEqual(issue.journal._id, self.journal._id)
+            self.assertEqual(issue.is_public, original.is_public)
+
+    def test_get_issue_for_upsert_prefers_document_with_target_id(self):
+        with current_app.app_context():
+            pid = "0000000320200003"
+            utils.makeOneIssue(
+                {
+                    "_id": "0000-0003-2020-v1-n1",
+                    "journal": self.journal,
+                    "pid": pid,
+                    "number": "1",
+                }
+            )
+            utils.makeOneIssue(
+                {
+                    "_id": "0000-0003-2020-v1",
+                    "journal": self.journal,
+                    "pid": pid,
+                    "number": None,
+                }
+            )
+
+            issue, old_ids = _get_issue_for_upsert(
+                _minimal_issue_data(
+                    self.journal._id,
+                    issue_id="0000-0003-2020-v1",
+                    pid=pid,
+                    number=None,
+                )
+            )
+
+            self.assertEqual(issue._id, "0000-0003-2020-v1")
+            self.assertEqual(old_ids, ["0000-0003-2020-v1-n1"])
+
+    def test_get_issue_for_upsert_does_not_lookup_by_id_without_pid(self):
+        with current_app.app_context():
+            data = _minimal_issue_data(
+                self.journal._id,
+                issue_id="0000-0003-no-pid",
+            )
+            data.pop("pid")
+            saved = IssueFactory(data, self.journal._id)
+            saved.save()
+
+            issue, old_ids = _get_issue_for_upsert(data)
+
+            self.assertIsNone(issue.pk)
+            self.assertEqual(old_ids, [])
+
+    def test_issue_factory_updates_existing_issue_when_id_changes_same_pid(self):
+        with current_app.app_context():
+            data = _minimal_issue_data(
+                self.journal._id,
+                issue_id="0000-0003-2020-v1-n1",
+                pid="0000000320200004",
+            )
+            first = IssueFactory(data, self.journal._id)
+            first.save()
+
+            data["id"] = "0000-0003-2020-v1"
+            data["number"] = None
+            issue, _ = _get_issue_for_upsert(data)
+            updated = IssueFactory(data, journal_id=None, issue=issue)
+
+            self.assertEqual(updated._id, "0000-0003-2020-v1")
+            self.assertEqual(updated.iid, "0000-0003-2020-v1")
+            self.assertEqual(updated.pid, "0000000320200004")
+            self.assertEqual(updated.journal._id, self.journal._id)
+            self.assertIsNone(updated.number)
+            self.assertEqual(updated.label, "v1")
 
 
 class AuxiliarArticleFactoryTestCase(BaseTestCase):

--- a/opac/tests/test_restapi.py
+++ b/opac/tests/test_restapi.py
@@ -124,6 +124,44 @@ class RestAPIIssueTestCase(RestAPIAuthMixin, BaseTestCase):
                 response.data, b'{"failed":false,"id":"1678-4464-1998-v29-n3"}\n'
             )
 
+    def test_add_issue_by_api_updates_by_pid_when_id_changes(self):
+        with current_app.app_context():
+            with self.client as client:
+                self._api_post(client, "restapi.journal", self.journal_dict)
+                response = self._api_post(
+                    client,
+                    "restapi.issue",
+                    self.issue_dict,
+                    journal_id=self.journal_dict.get("id"),
+                )
+            self.assertEqual(response.status_code, 200)
+
+            old_id = self.issue_dict["id"]
+            article = makeOneArticle({"journal": self.journal_dict["id"], "issue": old_id})
+
+            payload = dict(self.issue_dict)
+            payload["id"] = "1678-4464-1998-v29"
+            payload["number"] = None
+
+            with self.client as client:
+                response = self._api_post(
+                    client,
+                    "restapi.issue",
+                    payload,
+                    journal_id=self.journal_dict.get("id"),
+                )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                response.data, b'{"failed":false,"id":"1678-4464-1998-v29"}\n'
+            )
+            article.reload()
+            self.assertEqual(article.issue.id, "1678-4464-1998-v29")
+            self.assertEqual(
+                models.Issue.objects.filter(pid=payload["pid"]).count(), 1
+            )
+            self.assertIsNone(models.Issue.objects.filter(_id=old_id).first())
+
     def test_add_issue_by_api_without_data(self):
         with current_app.app_context():
             # journal

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -42,7 +42,7 @@ from webapp import dbsql
 
 from .choices import INDEX_NAME, JOURNAL_STATUS, STUDY_AREAS
 from .models import User
-from .factory import JournalFactory, IssueFactory, ArticleFactory
+from .factory import JournalFactory, IssueFactory, ArticleFactory, _get_issue_for_upsert
 from .utils import utils
 
 HIGHLIGHTED_TYPES = (
@@ -1922,6 +1922,36 @@ def add_journal(data):
     return journal.save()
 
 
+def relink_articles_to_issue(old_issue_ids, new_issue):
+    """Re-point articles and press releases from old issue `_id`s, then delete them.
+
+    Must run after the issue with the new `_id` is saved. Order matters because
+    `Article.issue` and `PressRelease.issue` use CASCADE on delete.
+    """
+    if not old_issue_ids:
+        return new_issue
+
+    unique_old_ids = [
+        old_id for old_id in dict.fromkeys(old_issue_ids) if old_id != new_issue.id
+    ]
+
+    for old_id in unique_old_ids:
+        Article.objects(issue=old_id).update(set__issue=new_issue)
+        PressRelease.objects(issue=old_id).update(set__issue=new_issue)
+
+    journal = new_issue.journal
+    if journal is not None:
+        journal.reload()
+        if journal.last_issue and journal.last_issue.iid in unique_old_ids:
+            create_last_issue_for_journal(journal, new_issue)
+            journal.save()
+
+    for old_id in unique_old_ids:
+        Issue.objects(pk=old_id).delete()
+
+    return new_issue
+
+
 def add_issue(data, journal_id, issue_order=None, _type="regular"):
     """
     This function has the responsability to create a journal using a data as dictionary.
@@ -1944,12 +1974,29 @@ def add_issue(data, journal_id, issue_order=None, _type="regular"):
         "updated": "2020-04-28T20:16:24.459467Z"
     }
 
+    Issues are located by ``pid``. A change of ``id``/``_id`` updates the
+    existing fascículo instead of creating a duplicate. Articles (and press
+    releases) that still point to the old `_id` are re-pointed.
+
     The mininal fields necessary to create a journal is:
 
 
     """
-    issue = IssueFactory(data, journal_id, issue_order=issue_order, _type=_type)
-    saved = issue.save()
+    issue, old_ids = _get_issue_for_upsert(data)
+    previous_id = issue.pk
+    issue = IssueFactory(
+        data, journal_id, issue_order=issue_order, _type=_type, issue=issue
+    )
+    # MongoDB cannot update `_id` in place. Reusing the same object and
+    # force-inserting writes a complete document under the new `_id`; the
+    # previous record is removed after articles are re-pointed.
+    if previous_id and previous_id != issue._id:
+        saved = issue.save(force_insert=True)
+    else:
+        saved = issue.save()
+
+    if old_ids:
+        relink_articles_to_issue(old_ids, saved)
 
     set_last_issue_and_issue_count(issue.journal)
     return saved

--- a/opac/webapp/factory.py
+++ b/opac/webapp/factory.py
@@ -115,11 +115,51 @@ def JournalFactory(data):
     return journal
 
 
-def IssueFactory(data, journal_id, issue_order=None, _type="regular"):
+def _get_issue_for_upsert(data):
+    """
+    Localiza o fascículo (issue) a ser atualizado ou inserido usando o ``pid`` e quaisquer `_id`s que precisam ser migrados.
+
+    A busca é feita apenas pelo ``pid`` (chave estável do site clássico). Entre os resultados,
+    o documento que já possui ``_id == data["id"]`` é preferido; caso contrário,
+    o documento existente é reutilizado para que o ``IssueFactory`` possa atribuir o novo ``_id``.
+
+    O MongoDB não permite alterar o `_id` diretamente. O objeto reutilizado é posteriormente inserido
+    com o novo `_id` e os registros antigos são retornados para que o chamador possa reatribuir artigos
+    e deletá-los.
+
+    Retorna:
+        tuple: ``(issue, old_ids)``, onde ``old_ids`` são documentos com o mesmo pid cujo `_id` difere de ``data["id"]``.
+    """
+    new_id = data["id"]
+    pid = data.get("pid") or None
+    old_ids = []
+    issue = None
+
+    if pid:
+        for existing in models.Issue.objects.filter(pid=pid):
+            if existing._id == new_id:
+                issue = existing
+            else:
+                old_ids.append(existing._id)
+
+    if issue is None:
+        if old_ids:
+            issue = models.Issue.objects.get(_id=old_ids[0])
+        else:
+            issue = models.Issue()
+
+    return issue, old_ids
+
+
+def IssueFactory(data, journal_id, issue_order=None, _type="regular", issue=None):
     """
     Realiza o registro fascículo utilizando o opac schema.
 
     Esta função pode lançar a exceção `models.Journal.DoesNotExist`.
+
+    A localização do documento existente (por pid) é responsabilidade do
+    chamador. Passe ``issue`` já resolvido por ``_get_issue_for_upsert``;
+    se omitido, um fascículo novo é instanciado.
 
     Para satisfazer a obrigatoriedade do ano para os "Fascículos" ahead,
     estamos fixando o ano de fascículos do tipo ``ahead`` com o valor 9999
@@ -127,12 +167,11 @@ def IssueFactory(data, journal_id, issue_order=None, _type="regular"):
 
     metadata = data
 
-    try:
-        issue = models.Issue.objects.get(_id=data["id"])
-    except models.Issue.DoesNotExist:
+    if issue is None:
         issue = models.Issue()
-    else:
-        journal_id = journal_id or issue.journal._id
+
+    if not journal_id and getattr(issue, "journal", None):
+        journal_id = issue.journal._id
 
     _type = (data["id"].endswith("-aop") and "ahead") or _type
 


### PR DESCRIPTION
## O que esse PR faz?

A API de atualização de issue (`POST/PUT /api/v1/issue`) passa a localizar o fascículo pelo **pid** (chave estável do site clássico), em vez de pelo `_id`.

Quando a identificação do fascículo muda (ex.: `number: "1"` vira `null` e o `_id` passa de `2215-4906-2024-v84-n1` para `2215-4906-2024-v84`), o pid permanece. Antes, isso criava um issue novo e deixava os artigos no `_id` antigo.

Agora o registro existente é atualizado. Se o `_id` mudar, os artigos, press releases e o `journal.last_issue` são reapontados para o novo `_id`, e o documento antigo é removido.

## Onde a revisão poderia começar?

1. [`opac/webapp/factory.py`](opac/webapp/factory.py) — `_get_issue_for_upsert` (busca só por pid)
2. [`opac/webapp/controllers.py`](opac/webapp/controllers.py) — `add_issue` e `relink_articles_to_issue`
3. Testes em `opac/tests/test_factory.py`, `opac/tests/test_controller_coverage.py` e `opac/tests/test_restapi.py`

## Como este poderia ser testado manualmente?

### Testes automatizados (Docker, Python 3.11)

```bash
docker compose -f docker-compose-dev.yml exec -T -w /app opac_webapp sh -c '
  export OPAC_CONFIG="/app/opac/webapp/config/templates/testing.template"
  flask --app opac.app test -p "test_factory.IssueFactoryTestCase"
  flask --app opac.app test -p "test_controller_coverage.AddIssuePidUpsertTests"
  flask --app opac.app test -p "test_restapi.RestAPIIssueTestCase"
'
```

### Teste manual na API (app em `:8000`)

Obter token:

```bash
curl -s -u 'seu@email:senha' -X POST http://localhost:8000/api/v1/auth
```

1. Criar o journal (se ainda não existir):

```bash
curl -s -X POST "http://localhost:8000/api/v1/journal?token=$TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{
    "id": "2215-4906",
    "title": "Revista de teste",
    "title_iso": "Rev. teste",
    "short_title": "Rev. Teste",
    "acronym": "rt",
    "scielo_issn": "2215-4906",
    "electronic_issn": "2215-4906",
    "is_public": true,
    "created": "2024-01-01T00:00:00.000000Z",
    "updated": "2024-01-01T00:00:00.000000Z",
    "status_history": [
      {"status": "current", "date": "2024-01-01T00:00:00.000000Z", "reason": ""}
    ]
  }'
```

2. Criar o issue com número (`...-v84-n1`):

```bash
curl -s -X POST "http://localhost:8000/api/v1/issue?journal_id=2215-4906&token=$TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{
    "id": "2215-4906-2024-v84-n1",
    "pid": "2215-490620240002",
    "publication_year": "2024",
    "volume": "84",
    "number": "1",
    "publication_months": {"range": [0, 0]},
    "created": "2025-12-10T21:44:40.000000Z",
    "updated": "2026-01-16T11:04:48.000000Z"
  }'
```

3. (Opcional) Associar um artigo ao `_id` antigo, direto no Mongo:

```bash
docker compose -f docker-compose-dev.yml exec opac_mongo mongosh opac --eval '
  db.article.insertOne({
    _id: "artigo-teste-1",
    aid: "artigo-teste-1",
    title: "Artigo de teste",
    is_public: true,
    issue: "2215-4906-2024-v84-n1",
    journal: "2215-4906",
    pid: "S2215-49062024000200001"
  })
'
```

4. Atualizar o mesmo pid sem o número (`id` novo):

```bash
curl -s -X POST "http://localhost:8000/api/v1/issue?journal_id=2215-4906&token=$TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{
    "id": "2215-4906-2024-v84",
    "pid": "2215-490620240002",
    "publication_year": "2024",
    "volume": "84",
    "number": null,
    "publication_months": {"range": [0, 0]},
    "created": "2025-12-10T21:44:40.000000Z",
    "updated": "2026-08-18T14:00:00.000000Z"
  }'
```

Resposta esperada: `{"failed": false, "id": "2215-4906-2024-v84"}`.

5. Conferir no Mongo:

```bash
docker compose -f docker-compose-dev.yml exec opac_mongo mongosh opac --eval '
  printjson(db.issue.find({pid: "2215-490620240002"}).toArray());
  print("artigos no _id antigo:", db.article.find({issue: "2215-4906-2024-v84-n1"}).count());
  print("artigos no _id novo:", db.article.find({issue: "2215-4906-2024-v84"}).count());
'
```

Aceite:

- um único issue com aquele pid
- `_id` / `iid` = `2215-4906-2024-v84`
- artigos (se existirem) apontando para o `_id` novo, nenhum no antigo

## Algum cenário de contexto que queira dar?

O `_id` do issue é derivado da identificação bibliográfica (`journal-year-volume-number`). Quando o número deixa de existir, a chave muda, mas o pid do site clássico permanece para manter o link vivo.

O MongoDB não permite alterar `_id` in-place. O fluxo é: gravar o documento completo com o novo `_id` (`save(force_insert=True)`), reapontar referências e apagar o registro antigo — nessa ordem, porque `Article.issue` tem `reverse_delete_rule=CASCADE`.

## Screenshots

N/A

## Quais são os tickets relevantes?

Relacionado à issue #542.

## Referências

N/A

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): alteração de lógica de upsert de issue; o pipeline roda no CI após a abertura da PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)
