### PR TITLE
Fix 404 na navegação anterior/seguinte quando o artigo destino não tem o idioma do artigo anterior.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ SQLITE_BACKUP_DIR = ../$(DATA_PATH)/backups/sqlite
 -include $(MONGO_ENV_FILE)
 MONGODB_AUTH_ARGS = --username="$(OPAC_MONGODB_USER)" --password="$(OPAC_MONGODB_PASS)" --authenticationDatabase="$(OPAC_MONGODB_AUTH_SOURCE)"
 
+# testing.template uses opac_test. Host publishes mongo on 127.0.0.1:27017;
+# inside the webapp container the hostname is OPAC_MONGODB_HOST (opac_mongo).
+TEST_MONGODB_HOST ?= $(if $(wildcard /.dockerenv),$(OPAC_MONGODB_HOST),127.0.0.1)
+
 define require_mongo_auth
 	@if [ -z "$(OPAC_MONGODB_USER)" ] || [ -z "$(OPAC_MONGODB_PASS)" ] || [ -z "$(OPAC_MONGODB_AUTH_SOURCE)" ]; then \
 		echo "❌ Define OPAC_MONGODB_USER, OPAC_MONGODB_PASS e OPAC_MONGODB_AUTH_SOURCE em $(MONGO_ENV_FILE)"; \
@@ -167,12 +171,23 @@ build_i18n:
 # help: test                           - run local tests
 .PHONY: test
 test: make_messages compile_messages build_i18n
-	export OPAC_CONFIG="config/templates/testing.template" && flask --app opac.app test
+	export OPAC_CONFIG="config/templates/testing.template" \
+		OPAC_MONGODB_HOST="$(TEST_MONGODB_HOST)" \
+		OPAC_MONGODB_USER="$(OPAC_MONGODB_USER)" \
+		OPAC_MONGODB_PASS="$(OPAC_MONGODB_PASS)" \
+		OPAC_MONGODB_AUTH_SOURCE="$(OPAC_MONGODB_AUTH_SOURCE)" && \
+		flask --app opac.app test
 
 # help: coverage                       - run tests with coverage (terminal + htmlcov/ + coverage.xml)
 .PHONY: coverage
 coverage:
-	export OPAC_CONFIG="config/templates/testing.template" && export FLASK_COVERAGE="1" && flask --app opac.app test
+	export OPAC_CONFIG="config/templates/testing.template" \
+		FLASK_COVERAGE="1" \
+		OPAC_MONGODB_HOST="$(TEST_MONGODB_HOST)" \
+		OPAC_MONGODB_USER="$(OPAC_MONGODB_USER)" \
+		OPAC_MONGODB_PASS="$(OPAC_MONGODB_PASS)" \
+		OPAC_MONGODB_AUTH_SOURCE="$(OPAC_MONGODB_AUTH_SOURCE)" && \
+		flask --app opac.app test
 
 # help: coverage_html                  - rebuild HTML report from the last .coverage data
 .PHONY: coverage_html

--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1107,6 +1107,39 @@ class ArticleControllerTestCase(BaseTestCase):
         self.assertEqual(article.id, result.id)
         self.assertIsNone(lang)
 
+    def test_get_article_falls_back_when_requested_lang_is_missing(self):
+        articles = self._make_same_issue_articles()
+        lang, result, nav = controllers.get_article(
+            articles[1].id,
+            articles[1].journal.url_segment,
+            "en",
+            gs_abstract=False,
+        )
+        self.assertEqual(articles[1].id, result.id)
+        self.assertEqual(lang, "es")
+        self.assertEqual(nav["previous_article"].id, articles[0].id)
+
+    def test_get_article_falls_back_abstract_lang_when_requested_is_missing(self):
+        articles = self._make_same_issue_articles()
+        lang, result, nav = controllers.get_article(
+            articles[1].id,
+            articles[1].journal.url_segment,
+            "en",
+            gs_abstract=True,
+        )
+        self.assertEqual(articles[1].id, result.id)
+        self.assertEqual(lang, "es")
+
+    def test_get_article_raises_when_abstract_languages_missing(self):
+        article = self._make_one({"abstract_languages": []})
+        with self.assertRaises(controllers.ArticleAbstractNotFoundError):
+            controllers.get_article(
+                article.id,
+                article.journal.url_segment,
+                "pt",
+                gs_abstract=True,
+            )
+
     def test_get_article_returns_next_article_which_has_abstract(self):
         """
         Teste da função controllers.get_article para retornar o artigo atual

--- a/opac/tests/test_controller_coverage.py
+++ b/opac/tests/test_controller_coverage.py
@@ -503,6 +503,17 @@ class ArticleLookupCoverageTests(BaseTestCase):
         article = utils.makeOneArticle({"abstract_languages": ["es"]})
         self.assertEqual(controllers.get_existing_lang(article, "pt", True), "es")
 
+    def test_get_existing_lang_keeps_none_when_lang_missing(self):
+        article = utils.makeOneArticle({"languages": ["pt"]})
+        self.assertIsNone(controllers.get_existing_lang(article, None, False))
+
+    def test_get_existing_lang_returns_none_when_no_languages(self):
+        article = utils.makeOneArticle(
+            {"original_language": "", "languages": []}
+        )
+        self.assertIsNone(controllers.get_existing_lang(article, "en", False))
+        self.assertIsNone(controllers.get_existing_lang(article, "en", True))
+
     def test_get_article_by_url_seg_requires_segment(self):
         with self.assertRaises(ValueError) as exc:
             controllers.get_article_by_url_seg("")

--- a/opac/tests/test_legacy_urls.py
+++ b/opac/tests/test_legacy_urls.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from unittest.mock import Mock, patch
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 from flask import current_app, url_for
 
@@ -400,9 +400,10 @@ class LegacyURLTestCase(BaseTestCase):
     @patch("webapp.utils.utils.fetch_data")
     def test_article_pdf_when_dont_have_the_pdf_translation(self, mock_fetch_data):
         """
-        Testa o acesso ao PDF pela URL antiga verificando em todas as versões do pid
-        campo ``scielo_pids`` e retornando o primeiro encontrado quando não existe a traduçã
-        URL testa: scielo.php?script=sci_pdf&pid=ISSN + ID DO número + ID DO ARTIGO&tlng=LANG CODE ["pt", "es", "en"]
+        Testa o acesso ao PDF pela URL antiga com ``tlng`` inexistente: o roteador
+        legado repassa ``lang``, e ``article_detail_v3`` faz 301 para o idioma
+        original (que tem PDF).
+        URL testa: scielo.php?script=sci_pdf&pid=...&tlng=xxx
         """
 
         mock_fetch_data.return_value = b"<content>"
@@ -460,7 +461,10 @@ class LegacyURLTestCase(BaseTestCase):
 
                 response = c.get(url, follow_redirects=True)
 
-                self.assertStatus(response, 404)
+                self.assertStatus(response, 200)
+                final_qs = parse_qs(urlparse(response.request.url).query)
+                self.assertEqual(final_qs.get("lang"), ["en"])
+                self.assertEqual(final_qs.get("format"), ["pdf"])
 
     @patch("requests.get")
     def test_article_pdf_looking_scielo_pids(self, mocked_requests_get):

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -784,16 +784,114 @@ class MainTestCase(BaseTestCase):
             )
 
             self.assertStatus(response, 301)
-            self.assertEqual(
-                response.location,
+            qs = parse_qs(urlparse(response.location).query)
+            self.assertEqual(qs.get("lang"), ["en"])
+            self.assertEqual(qs.get("format"), ["html"])
+            self.assertIn("ilang", qs)
+
+    def test_article_detail_v3_redirects_when_requested_lang_unavailable(self):
+        """Navegação com lang do artigo atual: 301 para o idioma disponível."""
+        with current_app.app_context():
+            utils.makeOneCollection()
+            journal = utils.makeOneJournal()
+            issue = utils.makeOneIssue({"journal": journal})
+            first = utils.makeOneArticle(
+                {
+                    "original_language": "en",
+                    "languages": ["en"],
+                    "issue": issue,
+                    "journal": journal,
+                    "order": "1",
+                }
+            )
+            second = utils.makeOneArticle(
+                {
+                    "original_language": "es",
+                    "languages": ["es"],
+                    "issue": issue,
+                    "journal": journal,
+                    "order": "2",
+                }
+            )
+
+            response = self.client.get(
+                url_for(
+                    "main.article_detail_v3",
+                    url_seg=journal.url_segment,
+                    article_pid_v3=second.aid,
+                    lang="en",
+                ),
+                follow_redirects=False,
+            )
+
+            self.assertStatus(response, 301)
+            parsed = urlparse(response.location)
+            self.assertIn(second.aid, parsed.path)
+            qs = parse_qs(parsed.query)
+            self.assertEqual(qs.get("lang"), ["es"])
+            self.assertEqual(qs.get("format"), ["html"])
+
+    def test_article_detail_v3_unavailable_lang_redirect_preserves_ilang(self):
+        with current_app.app_context():
+            utils.makeOneCollection()
+            journal = utils.makeOneJournal()
+            issue = utils.makeOneIssue({"journal": journal})
+            article = utils.makeOneArticle(
+                {
+                    "original_language": "es",
+                    "languages": ["es"],
+                    "issue": issue,
+                    "journal": journal,
+                }
+            )
+
+            response = self.client.get(
                 url_for(
                     "main.article_detail_v3",
                     url_seg=journal.url_segment,
                     article_pid_v3=article.aid,
-                    format="html",
+                    lang="en",
+                    ilang="en",
+                ),
+                follow_redirects=False,
+            )
+
+            self.assertStatus(response, 301)
+            qs = parse_qs(urlparse(response.location).query)
+            self.assertEqual(qs.get("lang"), ["es"])
+            self.assertEqual(qs.get("ilang"), ["en"])
+
+    def test_article_detail_v3_redirects_abstract_when_requested_lang_unavailable(self):
+        with current_app.app_context():
+            utils.makeOneCollection()
+            journal = utils.makeOneJournal()
+            issue = utils.makeOneIssue({"journal": journal})
+            article = utils.makeOneArticle(
+                {
+                    "original_language": "es",
+                    "languages": ["es"],
+                    "abstracts": [{"language": "es", "text": "Resumen"}],
+                    "abstract_languages": ["es"],
+                    "issue": issue,
+                    "journal": journal,
+                }
+            )
+
+            response = self.client.get(
+                url_for(
+                    "main.article_detail_v3",
+                    url_seg=journal.url_segment,
+                    article_pid_v3=article.aid,
+                    part="abstract",
                     lang="en",
                 ),
+                follow_redirects=False,
             )
+
+            self.assertStatus(response, 301)
+            self.assertIn("/abstract/", response.location)
+            qs = parse_qs(urlparse(response.location).query)
+            self.assertEqual(qs.get("lang"), ["es"])
 
     def test_article_detail_pid_redirect(self):
         """

--- a/opac/tests/test_makefile.py
+++ b/opac/tests/test_makefile.py
@@ -92,6 +92,7 @@ EXPECTED_FRAGMENTS = {
     "coverage": (
         'OPAC_CONFIG="config/templates/testing.template"',
         'FLASK_COVERAGE="1"',
+        "OPAC_MONGODB_HOST=",
         "flask --app opac.app test",
     ),
     "coverage_html": ("coverage html", "HTML report:"),
@@ -135,6 +136,7 @@ EXPECTED_FRAGMENTS = {
         "pybabel extract",
         "pybabel compile",
         'OPAC_CONFIG="config/templates/testing.template"',
+        "OPAC_MONGODB_HOST=",
         "flask --app opac.app test",
     ),
     "test_coverage": (
@@ -302,14 +304,14 @@ class MakefileRecipesTestCase(unittest.TestCase):
             (
                 "BACKUP_DATE=2024-01-01",
                 "mongorestore",
-                "../data_opac_dev/backups/$BACKUP_DATE",
+                "/data_opac_dev/backups/$BACKUP_DATE",
             ),
         )
 
     def test_mongodb_backup_uses_dev_data_path_by_default(self):
         result = make_dry_run("mongodb_backup")
         self._assert_fragments(
-            result, "mongodb_backup", ("../data_opac_dev/backups/",)
+            result, "mongodb_backup", ("/data_opac_dev/backups/",)
         )
 
     def test_mongodb_backup_uses_prod_data_path_with_prod_compose(self):
@@ -317,7 +319,7 @@ class MakefileRecipesTestCase(unittest.TestCase):
             "mongodb_backup", "compose=docker-compose.yml"
         )
         self._assert_fragments(
-            result, "mongodb_backup", ("../data_opac_prod/backups/",)
+            result, "mongodb_backup", ("/data_opac_prod/backups/",)
         )
 
     def test_makefile_includes_compose_specific_mongo_env_file(self):

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1103,7 +1103,12 @@ def get_article_by_aid(
 
 
 def get_article(aid, journal_url_seg, lang=None, gs_abstract=False):
-    article = get_article_by_aid(aid, journal_url_seg, lang, gs_abstract)
+    article = get_article_by_aid(aid, journal_url_seg)
+
+    if gs_abstract and not article.abstract_languages:
+        raise ArticleAbstractNotFoundError(aid)
+
+    lang = get_existing_lang(article, lang, gs_abstract)
 
     # add filter publication_date__lte_today_date
     kwargs = {}
@@ -1131,16 +1136,24 @@ def get_article(aid, journal_url_seg, lang=None, gs_abstract=False):
 def get_existing_lang(article, lang, gs_abstract):
     """
     Evita falha de recurso não encontrado,
-    quando se navega entre os documentos e/ou resumos,
+    quando se navega entre os documentos e/ou resumos.
     """
-    # ajusta o idioma
+    if not lang:
+        return lang
+
     if gs_abstract:
-        langs = article.abstract_languages
+        langs = list(article.abstract_languages or [])
     else:
-        langs = [article.original_language] + article.languages
-    if lang not in langs:
-        lang = langs[0]
-    return lang
+        langs = []
+        if article.original_language:
+            langs.append(article.original_language)
+        langs.extend(article.languages or [])
+
+    if lang in langs:
+        return lang
+    if not langs:
+        return None
+    return langs[0]
 
 
 def get_article_by_url_seg(url_seg_article, **kwargs):

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1231,11 +1231,11 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
         abort(404, _("Não existe '{}'. No seu lugar use '{}'").format(part, "abstract"))
 
     try:
-        qs_lang, article, nav = controllers.get_article(
+        registered_lang, article, nav = controllers.get_article(
             article_pid_v3, url_seg, requested_lang, gs_abstract,
         )
-        if qs_lang != requested_lang or not qs_lang:
-            target_lang = qs_lang or article.original_language
+        if registered_lang != requested_lang or not registered_lang:
+            target_lang = registered_lang or article.original_language
             if not target_lang:
                 raise controllers.ArticleLangNotFoundError
             redirect_kwargs = {
@@ -1272,12 +1272,12 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
     def _handle_html():
         citation_pdf_url = None
         for pdf_data in article.pdfs:
-            if pdf_data.get("lang") == qs_lang:
+            if pdf_data.get("lang") == registered_lang:
                 citation_pdf_url = url_for(
                     "main.article_detail_v3",
                     url_seg=article.journal.url_segment,
                     article_pid_v3=article_pid_v3,
-                    lang=qs_lang,
+                    lang=registered_lang,
                     format="pdf",
                 )
                 break
@@ -1291,7 +1291,7 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
         if citation_pdf_url:
             citation_pdf_url = "{}{}".format(website, citation_pdf_url)
         try:
-            html, text_languages = render_html(article, qs_lang, gs_abstract)
+            html, text_languages = render_html(article, registered_lang, gs_abstract)
         except (ValueError, utils.NonRetryableError):
             abort(404, _("HTML do Artigo não encontrado ou indisponível"))
         except utils.RetryableError as exc:
@@ -1332,7 +1332,7 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
             "html": html,
             "citation_pdf_url": citation_pdf_url,
             "citation_xml_url": citation_xml_url,
-            "article_lang": qs_lang,
+            "article_lang": registered_lang,
             "text_versions": text_versions,
             "related_links": controllers.related_links(article),
             "gs_abstract": gs_abstract,
@@ -1345,7 +1345,7 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
         if not article.pdfs:
             abort(404, _("PDF do Artigo não encontrado"))
 
-        pdf_info = [pdf for pdf in article.pdfs if pdf["lang"] == qs_lang]
+        pdf_info = [pdf for pdf in article.pdfs if pdf["lang"] == registered_lang]
         if len(pdf_info) != 1:
             abort(404, _("PDF do Artigo não encontrado"))
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1223,7 +1223,7 @@ def article_detail(url_seg, url_seg_issue, url_seg_article, lang_code=""):
 @main.route("/j/<string:url_seg>/a/<string:article_pid_v3>/<string:part>/")
 @cache.cached(key_prefix=cache_key_with_lang)
 def article_detail_v3(url_seg, article_pid_v3, part=None):
-    qs_lang = request.args.get("lang", type=str) or None
+    requested_lang = request.args.get("lang", type=str) or None
     qs_format = request.args.get("format", "html", type=str)
 
     gs_abstract = part == "abstract"
@@ -1232,21 +1232,24 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
 
     try:
         qs_lang, article, nav = controllers.get_article(
-            article_pid_v3, url_seg, qs_lang, gs_abstract,
+            article_pid_v3, url_seg, requested_lang, gs_abstract,
         )
-        if not qs_lang:
-            if article.original_language:
-                return redirect(
-                    url_for(
-                        "main.article_detail_v3",
-                        url_seg=url_seg,
-                        article_pid_v3=article_pid_v3,
-                        format=qs_format,
-                        lang=article.original_language,
-                    ),
-                    code=301,
-                )
-            raise controllers.ArticleLangNotFoundError
+        if qs_lang != requested_lang or not qs_lang:
+            target_lang = qs_lang or article.original_language
+            if not target_lang:
+                raise controllers.ArticleLangNotFoundError
+            redirect_kwargs = {
+                "url_seg": url_seg,
+                "article_pid_v3": article_pid_v3,
+                "format": qs_format,
+                "lang": target_lang,
+            }
+            if gs_abstract:
+                redirect_kwargs["part"] = "abstract"
+            return redirect(
+                url_for_with_ilang("main.article_detail_v3", **redirect_kwargs),
+                code=301,
+            )
     except controllers.PreviousOrNextArticleNotFoundError as e:
         if gs_abstract:
             abort(404, _("Resumo inexistente"))


### PR DESCRIPTION
## O que esse PR faz?

Corrige o 404 na navegação **Anterior/Seguinte** (e resumos) quando o documento destino não tem o `lang` do artigo atual.

Os botões de navegação passam `lang` como preferência (idioma do documento que o usuário está lendo). Se o vizinho não tiver texto nesse idioma, a página falhava. Agora o backend:

- busca o artigo só pelo `aid` (sem filtrar `languages`)
- resolve o idioma com `get_existing_lang` (pedido, se existir; senão o primeiro disponível)
- responde **301** para a URL canônica (`lang` resolvido), preservando `ilang`, `format` e `part=abstract`

`ilang` (interface) e `lang` (conteúdo) continuam independentes. Os templates **não** foram alterados.

Também corrige a **execução dos testes com MongoDB em `--auth`**: `make test` / `make coverage` passam `OPAC_MONGODB_USER`, `OPAC_MONGODB_PASS` e `OPAC_MONGODB_AUTH_SOURCE` a partir de `.envs/.development/.mongo` (no host usam `127.0.0.1`). Sem isso, o Flask subia sem credenciais e o pymongo falhava com `createIndexes requires authentication`. Nenhum segredo é commitado — as credenciais continuam só no arquivo `.mongo`.

## Onde a revisão poderia começar?

1. [`opac/webapp/controllers.py`](opac/webapp/controllers.py) — `get_article` e `get_existing_lang`
2. [`opac/webapp/main/views.py`](opac/webapp/main/views.py) — redirect 301 em `article_detail_v3`
3. [`opac/tests/test_controller.py`](opac/tests/test_controller.py) e [`opac/tests/test_main_views.py`](opac/tests/test_main_views.py) — fallback e 301
4. [`Makefile`](Makefile) — env de Mongo nos alvos `test` e `coverage`

## Como este poderia ser testado manualmente?

1. Abrir o TOC em inglês: https://www.scielo.br/j/dados/i/2026.v69n1/?ilang=en
2. Entrar no editorial pelo link **Text** `en`
3. Clicar em **Seguinte**
4. O artigo Guizardi (só texto em `es`) deve abrir com **200**, URL canônica `lang=es`, interface ainda em inglês (`ilang=en`) — sem 404
5. Confirmar que, se o próximo artigo **tiver** inglês, ele continua abrindo em `lang=en`
6. (Opcional) Testes locais, com Mongo autenticado:

```bash
make test
```

Ou, com o Click (um `-p` por invocação):

```bash
export OPAC_CONFIG="config/templates/testing.template"
export OPAC_MONGODB_HOST=127.0.0.1
export OPAC_MONGODB_USER=opac_user
export OPAC_MONGODB_PASS=123
export OPAC_MONGODB_AUTH_SOURCE=opac

flask --app opac.app test -p test_controller
flask --app opac.app test -p test_main_views
flask --app opac.app test -p test_legacy_urls
```

**Nota:** o usuário de desenvolvimento precisa de permissão no banco `opac_test` (os testes não usam o `opac` de dev). Ex.: `dbOwner` em `opac_test` para o `opac_user`.

## Algum cenário de contexto que queira dar?

O TOC em inglês oferece o editorial em `en`. O botão Seguinte copia `lang=en` para o próximo documento. O artigo seguinte (Guizardi) só tem texto em espanhol; o filtro `languages=en` gerava 404.

O roteador legado (`sci_pdf` / `tlng`) já fazia fallback para `original_language`. `get_existing_lang` existia com o mesmo objetivo, mas não era chamada no fluxo da página de artigo.

## Screenshots

N/A

## Quais são os tickets relevantes?

- Closes https://github.com/scieloorg/opac_5/issues/548

## Referências

- Comportamento já existente em `router_legacy` (`tlng` → `original_language`)
- `url_for_with_ilang` para preservar o idioma da interface

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): validação ocorrerá no CI do próprio PR após o push.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)