### PR TITLE
Atualiza issue pelo pid para não duplicar fascículo quando o _id muda

### DIFF
--- a/opac/tests/test_controller_coverage.py
+++ b/opac/tests/test_controller_coverage.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from flask import current_app
 from flask_babel import gettext as __
-from opac_schema.v1.models import Article, News, PressRelease
+from opac_schema.v1.models import Article, Issue, News, PressRelease
 from webapp import controllers
 from webapp.controllers import ArticleJournalNotFoundError
 
@@ -992,6 +992,149 @@ class FactoryWrapperCoverageTests(BaseTestCase):
             "http://minio.scielo.org/documentstore/example.xml",
         )
         self.assertEqual(article.aid, "article-coverage-id")
+
+
+class AddIssuePidUpsertTests(BaseTestCase):
+    def _issue_payload(self, issue_id, pid, **overrides):
+        data = {
+            "id": issue_id,
+            "publication_year": "2020",
+            "volume": "1",
+            "number": "1",
+            "publication_months": {"range": [1, 3]},
+            "pid": pid,
+            "created": "2020-01-01T00:00:00.000000Z",
+            "updated": "2020-01-02T00:00:00.000000Z",
+        }
+        data.update(overrides)
+        return data
+
+    def test_add_issue_updates_by_pid_when_id_changes_and_relinks_articles(self):
+        journal = utils.makeOneJournal({"_id": "0000-pid-1"})
+        pid = "0000pid120200002"
+        old_id = "0000-pid-1-2020-v1-n1"
+        new_id = "0000-pid-1-2020-v1"
+
+        controllers.add_issue(self._issue_payload(old_id, pid), journal.jid)
+        article = utils.makeOneArticle({"journal": journal, "issue": old_id})
+
+        updated = controllers.add_issue(
+            self._issue_payload(new_id, pid, number=None),
+            journal.jid,
+        )
+
+        self.assertEqual(updated._id, new_id)
+        self.assertEqual(updated.pid, pid)
+        self.assertEqual(Issue.objects.filter(pid=pid).count(), 1)
+        self.assertIsNone(Issue.objects.filter(_id=old_id).first())
+
+        article.reload()
+        self.assertEqual(article.issue.id, new_id)
+
+    def test_add_issue_does_not_relink_articles_when_id_is_unchanged(self):
+        journal = utils.makeOneJournal({"_id": "0000-pid-2"})
+        pid = "0000pid220200002"
+        issue_id = "0000-pid-2-2020-v1-n1"
+
+        controllers.add_issue(self._issue_payload(issue_id, pid), journal.jid)
+        article = utils.makeOneArticle({"journal": journal, "issue": issue_id})
+
+        updated = controllers.add_issue(
+            self._issue_payload(issue_id, pid, publication_year="2021"),
+            journal.jid,
+        )
+
+        self.assertEqual(updated._id, issue_id)
+        self.assertEqual(Issue.objects.count(), 1)
+        article.reload()
+        self.assertEqual(article.issue.id, issue_id)
+
+    def test_add_issue_merges_duplicate_issues_with_same_pid(self):
+        journal = utils.makeOneJournal({"_id": "0000-pid-3"})
+        pid = "0000pid320200002"
+        old_id = "0000-pid-3-2020-v1-n1"
+        new_id = "0000-pid-3-2020-v1"
+
+        old_issue = utils.makeOneIssue(
+            {"_id": old_id, "journal": journal, "pid": pid, "number": "1"}
+        )
+        utils.makeOneIssue(
+            {"_id": new_id, "journal": journal, "pid": pid, "number": None}
+        )
+        article = utils.makeOneArticle({"journal": journal, "issue": old_issue})
+
+        updated = controllers.add_issue(
+            self._issue_payload(new_id, pid, number=None),
+            journal.jid,
+        )
+
+        self.assertEqual(updated._id, new_id)
+        self.assertEqual(Issue.objects.filter(pid=pid).count(), 1)
+        self.assertIsNone(Issue.objects.filter(_id=old_id).first())
+        article.reload()
+        self.assertEqual(article.issue.id, new_id)
+
+    def test_add_issue_without_pid_creates_issue(self):
+        journal = utils.makeOneJournal({"_id": "0000-pid-4"})
+        issue_id = "0000-pid-4-2020-v1-n1"
+        payload = self._issue_payload(issue_id, pid="")
+        payload.pop("pid")
+
+        created = controllers.add_issue(payload, journal.jid)
+
+        self.assertEqual(created._id, issue_id)
+        self.assertEqual(Issue.objects.count(), 1)
+
+    def test_add_issue_creates_new_record_when_pid_is_unknown(self):
+        journal = utils.makeOneJournal({"_id": "0000-pid-5"})
+        utils.makeOneIssue(
+            {
+                "_id": "0000-pid-5-2020-v1-n1",
+                "journal": journal,
+                "pid": "0000pid520200001",
+            }
+        )
+
+        created = controllers.add_issue(
+            self._issue_payload("0000-pid-5-2020-v2-n1", "0000pid520200002"),
+            journal.jid,
+        )
+
+        self.assertEqual(created._id, "0000-pid-5-2020-v2-n1")
+        self.assertEqual(Issue.objects.count(), 2)
+
+    def test_add_issue_relinks_press_release_and_last_issue_iid(self):
+        old_id = "0000-pid-6-2020-v1-n1"
+        new_id = "0000-pid-6-2020-v1"
+        pid = "0000pid620200002"
+        last_issue = utils.getLastIssue({"iid": old_id, "url_segment": "2020.v1n1"})
+        journal = utils.makeOneJournal(
+            {"_id": "0000-pid-6", "last_issue": last_issue}
+        )
+        controllers.add_issue(self._issue_payload(old_id, pid), journal.jid)
+        article = utils.makeOneArticle({"journal": journal, "issue": old_id})
+        press_release = PressRelease(
+            _id=str(uuid4().hex),
+            title="PR",
+            language="pt",
+            content="<p>content</p>",
+            journal=journal.id,
+            issue=old_id,
+            article=article.id,
+            url="http://example.com/pr",
+            publication_date=datetime.datetime(2024, 1, 1),
+        ).save()
+
+        updated = controllers.add_issue(
+            self._issue_payload(new_id, pid, number=None),
+            journal.jid,
+        )
+
+        press_release.reload()
+        journal.reload()
+        self.assertEqual(press_release.issue.id, new_id)
+        self.assertEqual(journal.last_issue.iid, updated.iid)
+        self.assertEqual(Issue.objects.filter(_id=old_id).count(), 0)
 
 
 class RemainingControllersCoverageTests(BaseTestCase):

--- a/opac/tests/test_factory.py
+++ b/opac/tests/test_factory.py
@@ -13,6 +13,7 @@ from webapp.factory import (
     IssueFactory,
     JournalFactory,
     _format_author_name,
+    _get_issue_for_upsert,
     isoformat_to_datetime,
 )
 
@@ -249,7 +250,8 @@ class IssueFactoryTestCase(BaseTestCase):
             first.save()
 
             data["publication_year"] = "2021"
-            updated = IssueFactory(data, journal_id=None)
+            issue, _ = _get_issue_for_upsert(data)
+            updated = IssueFactory(data, journal_id=None, issue=issue)
 
             self.assertEqual(updated._id, first._id)
             self.assertEqual(updated.journal._id, self.journal._id)
@@ -348,6 +350,94 @@ class IssueFactoryTestCase(BaseTestCase):
                 _type="special",
             )
             self.assertEqual(issue.type, "special")
+
+    def test_get_issue_for_upsert_finds_by_pid_when_id_changes(self):
+        with current_app.app_context():
+            data = _minimal_issue_data(
+                self.journal._id,
+                issue_id="0000-0003-2020-v1-n1",
+                pid="0000000320200002",
+            )
+            original = IssueFactory(data, self.journal._id)
+            original.save()
+
+            data["id"] = "0000-0003-2020-v1"
+            data["number"] = None
+            issue, old_ids = _get_issue_for_upsert(data)
+
+            self.assertEqual(old_ids, ["0000-0003-2020-v1-n1"])
+            self.assertEqual(issue._id, original._id)
+            self.assertEqual(issue.journal._id, self.journal._id)
+            self.assertEqual(issue.is_public, original.is_public)
+
+    def test_get_issue_for_upsert_prefers_document_with_target_id(self):
+        with current_app.app_context():
+            pid = "0000000320200003"
+            utils.makeOneIssue(
+                {
+                    "_id": "0000-0003-2020-v1-n1",
+                    "journal": self.journal,
+                    "pid": pid,
+                    "number": "1",
+                }
+            )
+            utils.makeOneIssue(
+                {
+                    "_id": "0000-0003-2020-v1",
+                    "journal": self.journal,
+                    "pid": pid,
+                    "number": None,
+                }
+            )
+
+            issue, old_ids = _get_issue_for_upsert(
+                _minimal_issue_data(
+                    self.journal._id,
+                    issue_id="0000-0003-2020-v1",
+                    pid=pid,
+                    number=None,
+                )
+            )
+
+            self.assertEqual(issue._id, "0000-0003-2020-v1")
+            self.assertEqual(old_ids, ["0000-0003-2020-v1-n1"])
+
+    def test_get_issue_for_upsert_does_not_lookup_by_id_without_pid(self):
+        with current_app.app_context():
+            data = _minimal_issue_data(
+                self.journal._id,
+                issue_id="0000-0003-no-pid",
+            )
+            data.pop("pid")
+            saved = IssueFactory(data, self.journal._id)
+            saved.save()
+
+            issue, old_ids = _get_issue_for_upsert(data)
+
+            self.assertIsNone(issue.pk)
+            self.assertEqual(old_ids, [])
+
+    def test_issue_factory_updates_existing_issue_when_id_changes_same_pid(self):
+        with current_app.app_context():
+            data = _minimal_issue_data(
+                self.journal._id,
+                issue_id="0000-0003-2020-v1-n1",
+                pid="0000000320200004",
+            )
+            first = IssueFactory(data, self.journal._id)
+            first.save()
+
+            data["id"] = "0000-0003-2020-v1"
+            data["number"] = None
+            issue, _ = _get_issue_for_upsert(data)
+            updated = IssueFactory(data, journal_id=None, issue=issue)
+
+            self.assertEqual(updated._id, "0000-0003-2020-v1")
+            self.assertEqual(updated.iid, "0000-0003-2020-v1")
+            self.assertEqual(updated.pid, "0000000320200004")
+            self.assertEqual(updated.journal._id, self.journal._id)
+            self.assertIsNone(updated.number)
+            self.assertEqual(updated.label, "v1")
 
 
 class AuxiliarArticleFactoryTestCase(BaseTestCase):

--- a/opac/tests/test_restapi.py
+++ b/opac/tests/test_restapi.py
@@ -124,6 +124,44 @@ class RestAPIIssueTestCase(RestAPIAuthMixin, BaseTestCase):
                 response.data, b'{"failed":false,"id":"1678-4464-1998-v29-n3"}\n'
             )
 
+    def test_add_issue_by_api_updates_by_pid_when_id_changes(self):
+        with current_app.app_context():
+            with self.client as client:
+                self._api_post(client, "restapi.journal", self.journal_dict)
+                response = self._api_post(
+                    client,
+                    "restapi.issue",
+                    self.issue_dict,
+                    journal_id=self.journal_dict.get("id"),
+                )
+            self.assertEqual(response.status_code, 200)
+
+            old_id = self.issue_dict["id"]
+            article = makeOneArticle({"journal": self.journal_dict["id"], "issue": old_id})
+
+            payload = dict(self.issue_dict)
+            payload["id"] = "1678-4464-1998-v29"
+            payload["number"] = None
+
+            with self.client as client:
+                response = self._api_post(
+                    client,
+                    "restapi.issue",
+                    payload,
+                    journal_id=self.journal_dict.get("id"),
+                )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                response.data, b'{"failed":false,"id":"1678-4464-1998-v29"}\n'
+            )
+            article.reload()
+            self.assertEqual(article.issue.id, "1678-4464-1998-v29")
+            self.assertEqual(
+                models.Issue.objects.filter(pid=payload["pid"]).count(), 1
+            )
+            self.assertIsNone(models.Issue.objects.filter(_id=old_id).first())
+
     def test_add_issue_by_api_without_data(self):
         with current_app.app_context():
             # journal

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -42,7 +42,7 @@ from webapp import dbsql
 
 from .choices import INDEX_NAME, JOURNAL_STATUS, STUDY_AREAS
 from .models import User
-from .factory import JournalFactory, IssueFactory, ArticleFactory
+from .factory import JournalFactory, IssueFactory, ArticleFactory, _get_issue_for_upsert
 from .utils import utils
 
 HIGHLIGHTED_TYPES = (
@@ -1935,6 +1935,36 @@ def add_journal(data):
     return journal.save()
 
 
+def relink_articles_to_issue(old_issue_ids, new_issue):
+    """Re-point articles and press releases from old issue `_id`s, then delete them.
+
+    Must run after the issue with the new `_id` is saved. Order matters because
+    `Article.issue` and `PressRelease.issue` use CASCADE on delete.
+    """
+    if not old_issue_ids:
+        return new_issue
+
+    unique_old_ids = [
+        old_id for old_id in dict.fromkeys(old_issue_ids) if old_id != new_issue.id
+    ]
+
+    for old_id in unique_old_ids:
+        Article.objects(issue=old_id).update(set__issue=new_issue)
+        PressRelease.objects(issue=old_id).update(set__issue=new_issue)
+
+    journal = new_issue.journal
+    if journal is not None:
+        journal.reload()
+        if journal.last_issue and journal.last_issue.iid in unique_old_ids:
+            create_last_issue_for_journal(journal, new_issue)
+            journal.save()
+
+    for old_id in unique_old_ids:
+        Issue.objects(pk=old_id).delete()
+
+    return new_issue
+
+
 def add_issue(data, journal_id, issue_order=None, _type="regular"):
     """
     This function has the responsability to create a journal using a data as dictionary.
@@ -1957,12 +1987,29 @@ def add_issue(data, journal_id, issue_order=None, _type="regular"):
         "updated": "2020-04-28T20:16:24.459467Z"
     }
 
+    Issues are located by ``pid``. A change of ``id``/``_id`` updates the
+    existing fascículo instead of creating a duplicate. Articles (and press
+    releases) that still point to the old `_id` are re-pointed.
+
     The mininal fields necessary to create a journal is:
 
 
     """
-    issue = IssueFactory(data, journal_id, issue_order=issue_order, _type=_type)
-    saved = issue.save()
+    issue, old_ids = _get_issue_for_upsert(data)
+    previous_id = issue.pk
+    issue = IssueFactory(
+        data, journal_id, issue_order=issue_order, _type=_type, issue=issue
+    )
+    # MongoDB cannot update `_id` in place. Reusing the same object and
+    # force-inserting writes a complete document under the new `_id`; the
+    # previous record is removed after articles are re-pointed.
+    if previous_id and previous_id != issue._id:
+        saved = issue.save(force_insert=True)
+    else:
+        saved = issue.save()
+
+    if old_ids:
+        relink_articles_to_issue(old_ids, saved)
 
     set_last_issue_and_issue_count(issue.journal)
     return saved

--- a/opac/webapp/factory.py
+++ b/opac/webapp/factory.py
@@ -115,11 +115,51 @@ def JournalFactory(data):
     return journal
 
 
-def IssueFactory(data, journal_id, issue_order=None, _type="regular"):
+def _get_issue_for_upsert(data):
+    """
+    Localiza o fascículo (issue) a ser atualizado ou inserido usando o ``pid`` e quaisquer `_id`s que precisam ser migrados.
+
+    A busca é feita apenas pelo ``pid`` (chave estável do site clássico). Entre os resultados,
+    o documento que já possui ``_id == data["id"]`` é preferido; caso contrário,
+    o documento existente é reutilizado para que o ``IssueFactory`` possa atribuir o novo ``_id``.
+
+    O MongoDB não permite alterar o `_id` diretamente. O objeto reutilizado é posteriormente inserido
+    com o novo `_id` e os registros antigos são retornados para que o chamador possa reatribuir artigos
+    e deletá-los.
+
+    Retorna:
+        tuple: ``(issue, old_ids)``, onde ``old_ids`` são documentos com o mesmo pid cujo `_id` difere de ``data["id"]``.
+    """
+    new_id = data["id"]
+    pid = data.get("pid") or None
+    old_ids = []
+    issue = None
+
+    if pid:
+        for existing in models.Issue.objects.filter(pid=pid):
+            if existing._id == new_id:
+                issue = existing
+            else:
+                old_ids.append(existing._id)
+
+    if issue is None:
+        if old_ids:
+            issue = models.Issue.objects.get(_id=old_ids[0])
+        else:
+            issue = models.Issue()
+
+    return issue, old_ids
+
+
+def IssueFactory(data, journal_id, issue_order=None, _type="regular", issue=None):
     """
     Realiza o registro fascículo utilizando o opac schema.
 
     Esta função pode lançar a exceção `models.Journal.DoesNotExist`.
+
+    A localização do documento existente (por pid) é responsabilidade do
+    chamador. Passe ``issue`` já resolvido por ``_get_issue_for_upsert``;
+    se omitido, um fascículo novo é instanciado.
 
     Para satisfazer a obrigatoriedade do ano para os "Fascículos" ahead,
     estamos fixando o ano de fascículos do tipo ``ahead`` com o valor 9999
@@ -127,12 +167,11 @@ def IssueFactory(data, journal_id, issue_order=None, _type="regular"):
 
     metadata = data
 
-    try:
-        issue = models.Issue.objects.get(_id=data["id"])
-    except models.Issue.DoesNotExist:
+    if issue is None:
         issue = models.Issue()
-    else:
-        journal_id = journal_id or issue.journal._id
+
+    if not journal_id and getattr(issue, "journal", None):
+        journal_id = issue.journal._id
 
     _type = (data["id"].endswith("-aop") and "ahead") or _type
 


### PR DESCRIPTION
## Summary
- Reaplica em `qa` o mesmo conteúdo do PR #547 (`issue-542`), que foi mergeado em `master` e depois revertido em `a072ebe6`.
- A API de atualização de issue (`POST/PUT /api/v1/issue`) localiza o fascículo pelo **pid** em vez do `_id`, evitando duplicar o issue quando a identificação muda.
- Se o `_id` mudar, artigos, press releases e `journal.last_issue` são reapontados e o documento antigo é removido.

## Por que um PR novo para qa
O #547 entrou em `master` e foi revertido lá. `qa` nunca chegou a receber esses commits. Esta branch parte do `qa` atual e cherry-pick dos 3 commits de `issue-542`.

## Test plan
- [ ] `flask --app opac.app test -p "test_factory.IssueFactoryTestCase"`
- [ ] `flask --app opac.app test -p "test_controller_coverage.AddIssuePidUpsertTests"`
- [ ] `flask --app opac.app test -p "test_restapi.RestAPIIssueTestCase"`
- [ ] Criar issue com pid, atualizar o mesmo pid com `_id` novo e confirmar um único documento + artigos reapontados

Relacionado à issue #542 e ao PR #547.
